### PR TITLE
M4/ROCM: fix hip_runtime.h path

### DIFF
--- a/config/m4/rocm.m4
+++ b/config/m4/rocm.m4
@@ -39,7 +39,7 @@ AC_DEFUN([ROCM_BUILD_FLAGS],
 # Parse value of ARG into appropriate LIBS, LDFLAGS, and
 # CPPFLAGS variables.
 AC_DEFUN([HIP_BUILD_FLAGS],
-    $4="-D__HIP_PLATFORM_AMD__ -I$1/include/hip -I$1/include"
+    $4="-D__HIP_PLATFORM_AMD__ -I$1/include/hip -I$1/include  -I$1/hip/include"
     $3="-L$1/hip/lib -L$1/lib"
     $2="-lamdhip64"
 )
@@ -111,7 +111,7 @@ AS_IF([test "x$with_rocm" != "xno"],
     hip_happy=no
     AC_CHECK_LIB([hip_hcc], [hipFree], [AC_MSG_WARN([Please install ROCm-3.7.0 or above])], [hip_happy=yes])
     AS_IF([test "x$hip_happy" = xyes],
-          [AC_CHECK_HEADERS([hip_runtime.h], [hip_happy=yes], [hip_happy=no])])
+          [AC_CHECK_HEADERS([hip/hip_runtime.h], [hip_happy=yes], [hip_happy=no])])
     AS_IF([test "x$hip_happy" = xyes],
           [AC_CHECK_LIB([amdhip64], [hipFree], [hip_happy=yes], [hip_happy=no])])
     AS_IF([test "x$hip_happy" = xyes], [HIP_CXXFLAGS="--std=gnu++11"], [])

--- a/src/components/tl/rccl/Makefile.am
+++ b/src/components/tl/rccl/Makefile.am
@@ -20,10 +20,10 @@ sources =             \
 
 module_LTLIBRARIES = libucc_tl_rccl.la
 libucc_tl_rccl_la_SOURCES  = $(sources)
-libucc_tl_rccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS) $(RCCL_CPPFLAGS)
+libucc_tl_rccl_la_CPPFLAGS = $(AM_CPPFLAGS) $(BASE_CPPFLAGS) $(ROCM_CPPFLAGS) $(HIP_CPPFLAGS) $(RCCL_CPPFLAGS)
 libucc_tl_rccl_la_CFLAGS   = $(BASE_CFLAGS)
-libucc_tl_rccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(ROCM_LDFLAGS) $(RCCL_LDFLAGS)
-libucc_tl_rccl_la_LIBADD   = $(ROCM_LIBS) $(RCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
+libucc_tl_rccl_la_LDFLAGS  = -version-info $(SOVERSION) --as-needed $(ROCM_LDFLAGS) $(HIP_LDFLAGS) $(RCCL_LDFLAGS)
+libucc_tl_rccl_la_LIBADD   = $(ROCM_LIBS) $(HIP_LIBS) $(RCCL_LIBADD) $(UCC_TOP_BUILDDIR)/src/libucc.la
 
 include $(top_srcdir)/config/module.am
 


### PR DESCRIPTION
## What
Fix hip include/lib path in configure and Makefile

## Why ?
When installing rocm package (e.g., 4.5.2), hip_runtime.h is installed
under $ROCM_PATH/hip/include/hip and UCC includes the path
hip/hip_runtime.h. Thus, we need to set -I$ROCM_PATH/hip and check
hip/hip_runtime.h (rather than hip_runtime.h) at configure.

At compiling time, the RCCL TL did not include HIP FLAGS but uses
functions from libamdhip64.so (e.g., hipStreamDestroy) and includes
hip/hip_runtime.h. This patch adds back CPPFLAGS, LDFLAGS, LIBS
for such hip components.

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
