### PR TITLE
TL/RCCL: fix allgatherv score with rocm mem type

### DIFF
--- a/src/components/tl/rccl/allgatherv/allgatherv.h
+++ b/src/components/tl/rccl/allgatherv/allgatherv.h
@@ -18,7 +18,7 @@ enum {
 };
 
 #define UCC_TL_RCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR                          \
-    "allgatherv:0-16k:@0#allgatherv:16k-1M:@1#allgatherv:1M-inf:@2"
+    "allgatherv:rocm:0-16k:@0#allgatherv:rocm:16k-1M:@1#allgatherv:rocm:1M-inf:@2"
 
 extern ucc_base_coll_alg_info_t
              ucc_tl_rccl_allgatherv_algs[UCC_TL_RCCL_ALLGATHERV_ALG_LAST + 1];


### PR DESCRIPTION
Previous version incorrectly specified score for all mem types with
allgatherv. It breaks host memory allgatherv because it was directed to
RCCL TL which does not handle such pattern. This patch fixes it by adding
the rocm mem type in UCC_TL_RCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
