### PR TITLE
TL/RCCL: add support for gather and scatter

### DIFF
--- a/src/components/tl/rccl/tl_rccl.h
+++ b/src/components/tl/rccl/tl_rccl.h
@@ -110,7 +110,9 @@ typedef struct ucc_tl_rccl_task {
      UCC_COLL_TYPE_ALLGATHER      | UCC_COLL_TYPE_ALLGATHERV |                 \
      UCC_COLL_TYPE_ALLREDUCE      | UCC_COLL_TYPE_BCAST      |                 \
      UCC_COLL_TYPE_REDUCE_SCATTER | UCC_COLL_TYPE_REDUCE     |                 \
-     UCC_COLL_TYPE_BARRIER)
+     UCC_COLL_TYPE_BARRIER        | UCC_COLL_TYPE_GATHER     |                 \
+     UCC_COLL_TYPE_GATHERV        | UCC_COLL_TYPE_SCATTER    |                 \
+     UCC_COLL_TYPE_SCATTERV)
 
 UCC_CLASS_DECLARE(ucc_tl_rccl_team_t, ucc_base_context_t *,
                   const ucc_base_team_params_t *);

--- a/src/components/tl/rccl/tl_rccl_coll.h
+++ b/src/components/tl/rccl/tl_rccl_coll.h
@@ -51,4 +51,12 @@ ucc_status_t ucc_tl_rccl_reduce_init(ucc_tl_rccl_task_t *task);
 
 ucc_status_t ucc_tl_rccl_barrier_init(ucc_tl_rccl_task_t *task);
 
+ucc_status_t ucc_tl_rccl_gather_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_gatherv_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_scatter_init(ucc_tl_rccl_task_t *task);
+
+ucc_status_t ucc_tl_rccl_scatterv_init(ucc_tl_rccl_task_t *task);
+
 #endif

--- a/src/components/tl/rccl/tl_rccl_team.c
+++ b/src/components/tl/rccl/tl_rccl_team.c
@@ -162,6 +162,18 @@ ucc_status_t ucc_tl_rccl_coll_init(ucc_base_coll_args_t *coll_args,
     case UCC_COLL_TYPE_BARRIER:
         status = ucc_tl_rccl_barrier_init(task);
         break;
+    case UCC_COLL_TYPE_GATHER:
+        status = ucc_tl_rccl_gather_init(task);
+        break;
+    case UCC_COLL_TYPE_GATHERV:
+        status = ucc_tl_rccl_gatherv_init(task);
+        break;
+    case UCC_COLL_TYPE_SCATTER:
+        status = ucc_tl_rccl_scatter_init(task);
+        break;
+    case UCC_COLL_TYPE_SCATTERV:
+        status = ucc_tl_rccl_scatterv_init(task);
+        break;
     default:
         tl_error(UCC_TASK_LIB(task),
                  "collective %d is not supported by rccl tl",


### PR DESCRIPTION
## What
Add support gather, gatherv, scatter, and scatterv operations. 

## Why ?
These operations were missed in the initial commit.
