### PR TITLE
BUILD/RCCL: Re-order m4 flags for RCCL

### DIFF
--- a/.ci/Dockerfile.centos8
+++ b/.ci/Dockerfile.centos8
@@ -4,13 +4,20 @@ FROM harbor.mellanox.com/torch-ucc/ucc/1.0.0/x86_64/centos8/cuda${CUDA_VER}:base
 RUN rm -rf  ${SRC_DIR}/ucc
 COPY . ${SRC_DIR}/ucc
 
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum install -y sudo && \
+    echo "swx-jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 #==============================================================================
 # Build UCC
 RUN ${SRC_DIR}/ucc/.ci/scripts/build_ucc.sh
 #==============================================================================
 # Install torch_ucc (UCC version) python module and build a wheel package
 RUN ${SRC_DIR}/ucc/.ci/scripts/install_torch_ucc.sh
+RUN chown -R 6213:11429 /opt/nvidia
 #==============================================================================
 RUN groupadd -g 11429 swx-jenkins
 RUN adduser --no-create-home --uid 6213 --gid 11429 --home /labhome/swx-jenkins swx-jenkins
 #==============================================================================
+USER swx-jenkins
+

--- a/.ci/job_matrix.yaml
+++ b/.ci/job_matrix.yaml
@@ -20,13 +20,13 @@ volumes:
     }
 
 env:
-  CUDA_VER: "11.4.2"
+  CUDA_VER: '11.4.2'
   UCC_URI_SUFFIX: "ucc/${UCC_VERSION}/x86_64/centos8/cuda${CUDA_VER}"
   UCC_DOCKER_IMAGE_NAME: "${registry_host}${registry_path}/${UCC_URI_SUFFIX}"
   NVIDIA_ROOT_DIR: "/opt/nvidia"
   SRC_DIR: "${NVIDIA_ROOT_DIR}/src"
   BIN_DIR: "${NVIDIA_ROOT_DIR}/bin"
-  DOCKER_OPT: "--pull always --network=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1 --security-opt seccomp=unconfined --cap-add=SYS_ADMIN --device=/dev/infiniband/ --gpus all --user root"
+  DOCKER_OPT: "--pull always --network=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1 --security-opt seccomp=unconfined --cap-add=SYS_ADMIN --device=/dev/infiniband/ --gpus all"
 
 docker_opt: "$DOCKER_OPT"
 

--- a/.ci/job_matrix.yaml
+++ b/.ci/job_matrix.yaml
@@ -54,6 +54,7 @@ runs_on_dockers:
 # bare metal
 runs_on_agents:
   - nodeLabel: "swx-clx01"
+  - nodeLabel: "ml-test-node-gpu"
 
 timeout_minutes: 360
 
@@ -72,7 +73,7 @@ steps:
   #============================================================================
   - name: Run Coverity
     credentialsId: "bc9a18d3-1153-449c-b924-7fc9249c9cc0"
-    agentSelector: "{nodeLabel: 'swx-clx01'}"
+    agentSelector: "{nodeLabel: 'ml-test-node-gpu'}"
     run: |
       export UCC_PASSWORD=$UCC_PASSWORD
       export UCC_USERNAME=$UCC_USERNAME

--- a/.ci/job_matrix.yaml
+++ b/.ci/job_matrix.yaml
@@ -1,46 +1,59 @@
 ---
-job: 'ucc'
+job: "ucc"
 
 step_allow_single_selector: true
 
-registry_host: 'harbor.mellanox.com'
-registry_path: '/torch-ucc'
-registry_auth: '05d98651-e11c-4a57-9cc6-52df79014b89'
+registry_host: "harbor.mellanox.com"
+registry_path: "/torch-ucc"
+registry_auth: "05d98651-e11c-4a57-9cc6-52df79014b89"
 
 volumes:
-  - { mountPath: '/hpc/local', hostPath: '/hpc/local' }
-  - { mountPath: '/auto/sw_tools', hostPath: '/auto/sw_tools' }
-  - { mountPath: '/.autodirect/mtrswgwork', hostPath: '/.autodirect/mtrswgwork' }
-  - { mountPath: '/.autodirect/sw/release', hostPath: '/.autodirect/sw/release' }
+  - { mountPath: "/hpc/local", hostPath: "/hpc/local" }
+  - { mountPath: "/auto/sw_tools", hostPath: "/auto/sw_tools" }
+  - {
+      mountPath: "/.autodirect/mtrswgwork",
+      hostPath: "/.autodirect/mtrswgwork",
+    }
+  - {
+      mountPath: "/.autodirect/sw/release",
+      hostPath: "/.autodirect/sw/release",
+    }
 
 env:
-  CUDA_VER: '11.4.2'
-  UCC_URI_SUFFIX: 'ucc/${UCC_VERSION}/x86_64/centos8/cuda${CUDA_VER}'
-  UCC_DOCKER_IMAGE_NAME: '${registry_host}${registry_path}/${UCC_URI_SUFFIX}'
-  NVIDIA_ROOT_DIR: '/opt/nvidia'
-  SRC_DIR: '${NVIDIA_ROOT_DIR}/src'
-  BIN_DIR: '${NVIDIA_ROOT_DIR}/bin'
-  DOCKER_OPT: '--pull always --network=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1 --security-opt seccomp=unconfined --cap-add=SYS_ADMIN --device=/dev/infiniband/ --gpus all --user root'
+  CUDA_VER: "11.4.2"
+  UCC_URI_SUFFIX: "ucc/${UCC_VERSION}/x86_64/centos8/cuda${CUDA_VER}"
+  UCC_DOCKER_IMAGE_NAME: "${registry_host}${registry_path}/${UCC_URI_SUFFIX}"
+  NVIDIA_ROOT_DIR: "/opt/nvidia"
+  SRC_DIR: "${NVIDIA_ROOT_DIR}/src"
+  BIN_DIR: "${NVIDIA_ROOT_DIR}/bin"
+  DOCKER_OPT: "--pull always --network=host --uts=host --ipc=host --ulimit stack=67108864 --ulimit memlock=-1 --security-opt seccomp=unconfined --cap-add=SYS_ADMIN --device=/dev/infiniband/ --gpus all --user root"
 
 docker_opt: "$DOCKER_OPT"
 
 kubernetes:
-  cloud: 'swx-k8s'
+  cloud: "swx-k8s"
+
+credentials:
+  - {
+      credentialsId: "bc9a18d3-1153-449c-b924-7fc9249c9cc0",
+      usernameVariable: "UCC_USERNAME",
+      passwordVariable: "UCC_PASSWORD",
+    }
 
 runs_on_dockers:
   - {
-    file: '.ci/Dockerfile.centos8',
-    name: 'centos8',
-    tag: '${BUILD_NUMBER}',
-    arch: 'x86_64',
-    uri: '${UCC_URI_SUFFIX}',
-    build_args: '--rm --no-cache --build-arg CUDA_VER=${CUDA_VER} --build-arg NVIDIA_ROOT_DIR=${NVIDIA_ROOT_DIR}',
-    cloud: 'swx-k8s'
-  }
+      file: ".ci/Dockerfile.centos8",
+      name: "centos8",
+      tag: "${BUILD_NUMBER}",
+      arch: "x86_64",
+      uri: "${UCC_URI_SUFFIX}",
+      build_args: "--rm --no-cache --build-arg CUDA_VER=${CUDA_VER} --build-arg NVIDIA_ROOT_DIR=${NVIDIA_ROOT_DIR}",
+      cloud: "swx-k8s",
+    }
 
 # bare metal
 runs_on_agents:
-  - nodeLabel: 'swx-clx01'
+  - nodeLabel: "swx-clx01"
 
 timeout_minutes: 360
 
@@ -55,6 +68,17 @@ steps:
       docker pull ${DOCKER_IMAGE_NAME}
       docker create -ti --rm $DOCKER_OPT ${DOCKER_IMAGE_NAME} /bin/bash > ${WORKSPACE}/ucc_docker.id
       docker start $(cat ${WORKSPACE}/ucc_docker.id)
+
+  #============================================================================
+  - name: Run Coverity
+    credentialsId: "bc9a18d3-1153-449c-b924-7fc9249c9cc0"
+    agentSelector: "{nodeLabel: 'swx-clx01'}"
+    run: |
+      export UCC_PASSWORD=$UCC_PASSWORD
+      export UCC_USERNAME=$UCC_USERNAME
+      echo "Running coverity"
+      ${WORKSPACE}/.ci/scripts/coverity.sh
+    archiveArtifacts: .ci/scripts/cov-build/*
 
   #============================================================================
   - name: Run UCC / Torch-UCC tests

--- a/.ci/scripts/coverity.sh
+++ b/.ci/scripts/coverity.sh
@@ -1,0 +1,139 @@
+#!/bin/bash -eE
+
+set -o pipefail
+
+handle_error() {
+    err_code=$?
+    local script_name="${0##*/}"
+    local last_command="${BASH_COMMAND}"
+    local error_line="${BASH_LINENO[${BASH_LINENO[@]} - 1]}"
+    echo "Error: ${script_name} - Command '${last_command}' failed at line ${error_line}."
+    exit $err_code
+}
+trap 'handle_error' ERR
+
+#
+# This script runs static code analysis using Coverity.
+# The script needs to be run from the main directory.
+#
+export UCC_PASSWORD=$UCC_PASSWORD
+export UCC_USERNAME=$UCC_USERNAME
+topdir=$(git rev-parse --show-toplevel)
+cd "$topdir" || exit 1
+module load hpcx-gcc
+module load dev/cuda12.1.1
+module load dev/nccl_2.18.3-1_cuda12.1.1_"$(uname -i)"
+module load tools/cov-2021.12
+previous_date=$(date -d "yesterday" +'%Y-%m-%d')
+HPCX_UCX_DIR=/hpc/local/benchmarks/daily/next/$previous_date/hpcx-gcc-redhat7/ucx
+HPCX_SHARP_DIR=/hpc/local/benchmarks/daily/next/$previous_date/hpcx-gcc-redhat7/sharp
+./autogen.sh
+./configure --with-nccl --with-tls=cuda,nccl,self,sharp,shm,ucp,mlx5 --with-ucx="${HPCX_UCX_DIR}" --with-sharp="${HPCX_SHARP_DIR}"
+make_opt="-j$(($(nproc) / 2 + 1))"
+COV_BUILD_DIR=$(dirname "$0")/cov-build
+mkdir -p "$COV_BUILD_DIR"
+COV_ANALYSE_OPTIONS+=" --all"
+COV_ANALYSE_OPTIONS+=" --enable-fnptr"
+COV_ANALYSE_OPTIONS+=" --fnptr-models"
+COV_ANALYSE_OPTIONS+=" --checker-option INFINITE_LOOP:report_bound_type_mismatch:true"
+COV_ANALYSE_OPTIONS+=" --checker-option RESOURCE_LEAK:allow_unimpl:true"
+
+function show_usage() {
+    echo ""
+    echo "Usage $(basename "$0") [options]"
+    echo ""
+    echo "Run static code analysis using Coverity, generate a defects report, and compare"
+    echo "the current report with the known issues filter file."
+    echo ""
+    echo "Script should be run from the main directory after makefiles have been generated."
+    echo ""
+    echo "Options:"
+    echo "--cov-analyze-args <args>  Additional arguments for cov-analyze."
+    echo "                           For more information, see cov-analyze manual."
+    echo ""
+    echo "--skip-coverity            Skip the Coverity stage."
+    echo "--skip-cov-build           Skip cov-build in the Coverity stage."
+    echo "                           filters out at least one issue."
+    echo ""
+    echo "-h, --help                 Show usage."
+    echo ""
+}
+
+# Build and run static code analysis with Coverity
+function build_with_coverity() {
+    echo "Building target with Coverity..."
+
+    if [ ! -f Makefile ]; then
+        echo "ERROR: Make file not found"
+        echo "Need to run from a directory with Make files"
+        return 1
+    fi
+
+    make clean >/dev/null
+    # Run cov-build
+    cov-build --dir "${COV_BUILD_DIR}" make $make_opt all >/dev/null
+    err_code=$?
+    return $err_code
+}
+
+# Run Coverity analysis
+function run_coverity_analysis() {
+    echo "Running Coverity analysis..."
+
+    # Run cov-analyze
+    # shellcheck disable=SC2086
+    cov-analyze --dir "${COV_BUILD_DIR}" "$@" --jobs auto $COV_ANALYSE_OPTIONS
+    err_code=$?
+    return $err_code
+}
+
+# Main function
+function main() {
+    # Parse command-line options
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --cov-analyze-args)
+            shift
+            COV_ANALYZE_ARGS="$1"
+            ;;
+        --skip-coverity)
+            SKIP_COVERITY=true
+            ;;
+        --skip-cov-build)
+            SKIP_COV_BUILD=true
+            ;;
+        -h | --help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Unrecognized option: $1"
+            show_usage
+            exit 1
+            ;;
+        esac
+        shift
+    done
+
+    # Build with Coverity
+    if [ -z "$SKIP_COVERITY" ] && [ -z "$SKIP_COV_BUILD" ]; then
+        build_with_coverity
+    fi
+
+    # Run Coverity analysis
+    if [ -z "$SKIP_COVERITY" ]; then
+    # shellcheck disable=SC2086
+        if ! run_coverity_analysis $COV_ANALYZE_ARGS; then
+            echo "Coverity analysis failed"
+            return 1
+        fi
+    fi
+
+    echo "Uploading to synopsys main coverity server"
+    cov-commit-defects --ssl --on-new-cert trust --host coverity.mellanox.com --port 8443 \
+    --user "${UCC_USERNAME}" --password "${UCC_PASSWORD}" --dir "$COV_BUILD_DIR" --stream ucc_master
+    return 0
+}
+
+# Call the main function
+main "$@"

--- a/.ci/scripts/coverity.sh
+++ b/.ci/scripts/coverity.sh
@@ -24,9 +24,6 @@ module load hpcx-gcc
 module load dev/cuda12.1.1
 module load dev/nccl_2.18.3-1_cuda12.1.1_"$(uname -i)"
 module load tools/cov-2021.12
-previous_date=$(date -d "yesterday" +'%Y-%m-%d')
-HPCX_UCX_DIR=/hpc/local/benchmarks/daily/next/$previous_date/hpcx-gcc-redhat7/ucx
-HPCX_SHARP_DIR=/hpc/local/benchmarks/daily/next/$previous_date/hpcx-gcc-redhat7/sharp
 ./autogen.sh
 ./configure --with-nccl --with-tls=cuda,nccl,self,sharp,shm,ucp,mlx5 --with-ucx="${HPCX_UCX_DIR}" --with-sharp="${HPCX_SHARP_DIR}"
 make_opt="-j$(($(nproc) / 2 + 1))"

--- a/.ci/scripts/run_dlrm.sh
+++ b/.ci/scripts/run_dlrm.sh
@@ -32,7 +32,6 @@ mpirun \
     -np $NP \
     --hostfile ${HOSTFILE} \
     --map-by node \
-    --allow-run-as-root \
     --mca plm_rsh_args '-p 12345' \
     -x PATH \
     -x LD_LIBRARY_PATH \
@@ -43,7 +42,6 @@ mpirun \
     -np $NP \
     --hostfile ${HOSTFILE} \
     --map-by node \
-    --allow-run-as-root \
     --mca plm_rsh_args '-p 12345' \
     -x PATH \
     -x LD_LIBRARY_PATH \
@@ -54,7 +52,6 @@ mpirun \
     -np $NP \
     --hostfile ${HOSTFILE} \
     --map-by node \
-    --allow-run-as-root \
     --mca plm_rsh_args '-p 12345' \
     -x PATH \
     -x LD_LIBRARY_PATH \

--- a/.ci/scripts/run_dlrm_docker.sh
+++ b/.ci/scripts/run_dlrm_docker.sh
@@ -19,4 +19,4 @@ HEAD_NODE=$(head -1 "$HOSTFILE")
 export HEAD_NODE
 
 #sudo ssh -p "${DOCKER_SSH_PORT}" "${HEAD_NODE}" /opt/nvidia/src/ucc/.ci/scripts/run_dlrm.sh cpu "/opt/nvidia/src/ucc/.ci/configs/${HEAD_NODE}/hostfile.txt"
-sudo ssh -p "${DOCKER_SSH_PORT}" "${HEAD_NODE}" /opt/nvidia/src/ucc/.ci/scripts/run_dlrm.sh gpu "/opt/nvidia/src/ucc/.ci/configs/${HEAD_NODE}/hostfile.txt"
+ssh -p "${DOCKER_SSH_PORT}" "${HEAD_NODE}" /opt/nvidia/src/ucc/.ci/scripts/run_dlrm.sh gpu "/opt/nvidia/src/ucc/.ci/configs/${HEAD_NODE}/hostfile.txt"

--- a/.ci/scripts/run_docker.sh
+++ b/.ci/scripts/run_docker.sh
@@ -41,13 +41,11 @@ DOCKER_RUN_ARGS="\
 --cap-add=SYS_ADMIN \
 --device=/dev/infiniband/ \
 --gpus all \
---user root \
 -it \
 -d \
 --rm \
 --name=${DOCKER_CONTAINER_NAME} \
 -v /labhome:/labhome \
--v /root/.ssh:/root/.ssh \
 "
 
 # shellcheck disable=SC2013
@@ -78,16 +76,16 @@ pdsh -w "${HOST_LIST}" -R ssh docker pull "${DOCKER_IMAGE_NAME}"
 for HOST in $(cat "$HOSTFILE"); do
     echo "INFO: start docker container on $HOST ..."
     # shellcheck disable=SC2029
-    sudo ssh "$HOST" "docker run \
+    ssh "$HOST" "docker run \
         ${DOCKER_RUN_ARGS} \
         ${DOCKER_IMAGE_NAME} \
-        bash -c '/usr/sbin/sshd -p ${DOCKER_SSH_PORT}; sleep infinity'"
+        bash -c 'sudo /usr/sbin/sshd -p ${DOCKER_SSH_PORT}; sleep infinity'"
     echo "INFO: start docker container on $HOST ... DONE"
 
     sleep 5
 
     echo "INFO: verify docker container on $HOST ..."
-    sudo ssh -p "${DOCKER_SSH_PORT}" "$HOST" hostname
-    sudo ssh -p "${DOCKER_SSH_PORT}" "$HOST" cat /proc/1/cgroup
+    ssh -p "${DOCKER_SSH_PORT}" "$HOST" hostname
+    ssh -p "${DOCKER_SSH_PORT}" "$HOST" cat /proc/1/cgroup
     echo "INFO: verify docker container on $HOST ... DONE"
 done

--- a/.ci/scripts/run_tests_ucc_mpi.sh
+++ b/.ci/scripts/run_tests_ucc_mpi.sh
@@ -46,7 +46,7 @@ function mpi_params {
         nnodes=$NNODES
     fi
     echo "-np $((nnodes*ppn)) --oversubscribe --hostfile ${HOSTFILE} \
---map-by ppr:$ppn:node --bind-to socket --allow-run-as-root \
+--map-by ppr:$ppn:node --bind-to socket  \
 -x PATH -x LD_LIBRARY_PATH --mca opal_common_ucx_opal_mem_hooks 1 --mca plm_rsh_args -p12345 \
 --mca coll ^ucc,hcoll \
 -x UCX_NET_DEVICES=$DEV:1"

--- a/.ci/scripts/run_tests_ucc_mpi_docker.sh
+++ b/.ci/scripts/run_tests_ucc_mpi_docker.sh
@@ -18,4 +18,4 @@ fi
 HEAD_NODE=$(head -1 "$HOSTFILE")
 export HEAD_NODE
 
-sudo ssh -p "${DOCKER_SSH_PORT}" "${HEAD_NODE}" /opt/nvidia/src/ucc/.ci/scripts/run_tests_ucc_mpi.sh "/opt/nvidia/src/ucc/.ci/configs/${HEAD_NODE}/hostfile.txt"
+ssh -p "${DOCKER_SSH_PORT}" "${HEAD_NODE}" /opt/nvidia/src/ucc/.ci/scripts/run_tests_ucc_mpi.sh "/opt/nvidia/src/ucc/.ci/configs/${HEAD_NODE}/hostfile.txt"

--- a/.github/workflows/clang-tidy-rocm.yaml
+++ b/.github/workflows/clang-tidy-rocm.yaml
@@ -6,7 +6,7 @@ env:
   OPEN_UCX_LINK: https://github.com/openucx/ucx
   OPEN_UCX_BRANCH: master
   CLANG_VER: 12
-  ROCM_VER: 5-4
+  ROCM_VER: 5.6.1
   LIBRARY_PATH: /tmp/ucx/install/lib
   LD_LIBRARY_PATH: /tmp/ucx/install/lib
 jobs:
@@ -23,7 +23,7 @@ jobs:
     - name: Install extra dependencies
       run: |
         curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/rocm-keyring.gpg
-        echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg]  https://repo.radeon.com/rocm/apt/debian focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
+        echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/5.6.1 focal main' | sudo tee /etc/apt/sources.list.d/rocm.list
         sudo apt-get update
         sudo apt-get install -y rocm-hip-sdk
     - name: Get UCX
@@ -31,7 +31,7 @@ jobs:
     - name: Build UCX
       run: |
         cd /tmp/ucx && ./autogen.sh
-        CC=clang-${CLANG_VER} CXX=clang++-${CLANG_VER} ./contrib/configure-release --without-java --without-go --disable-numa --prefix $PWD/install --with-rocm=/opt/rocm
+        CC=gcc CXX=g++ ./contrib/configure-release --without-java --without-go --disable-numa --prefix $PWD/install --with-rocm=/opt/rocm
         make -j install
     - uses: actions/checkout@v1
     - name: Build UCC

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -37,7 +37,7 @@ jobs:
             fi
           fi
           H1="CODESTYLE|REVIEW|CORE|UTIL|TEST|API|DOCS|TOOLS|BUILD|MC|EC|SCHEDULE|TOPO"
-          H2="CI|CL/|TL/|MC/|EC/|UCP|NCCL|SHARP|BASIC|HIER|CUDA|CPU|EE|RCCL|ROCM|SELF|MLX5"
+          H2="CI|CL/|TL/|MC/|EC/|UCP|SHM|NCCL|SHARP|BASIC|HIER|CUDA|CPU|EE|RCCL|ROCM|SELF|MLX5"
           if ! echo $msg | grep -qP '^Merge |^'"(($H1)|($H2))"'+: \w'
           then
             echo "Wrong header"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ env:
   OPEN_MPI_LINK: https://github.com/open-mpi/ompi.git
   OPEN_MPI_BRANCH: v5.0.x
   IMB_LINK: https://github.com/intel/mpi-benchmarks.git
-  IMB_COLLS: allgather,allgatherv,allreduce,alltoall,alltoallv,barrier,bcast,reduce
+  IMB_COLLS: allgather,allgatherv,allreduce,alltoall,alltoallv,barrier,bcast,gather,gatherv,reduce,reduce_scatter,reduce_scatter_block,scatter,scatterv
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/config/m4/rccl.m4
+++ b/config/m4/rccl.m4
@@ -36,8 +36,8 @@ AS_IF([test "x$rccl_checked" != "xyes"],[
 
         AS_IF([test "x$rocm_happy" = "xyes"],
         [
-            CPPFLAGS="$HIP_CPPFLAGS $CPPFLAGS"
-            LDFLAGS="$ROCM_LDFLAGS $LDFLAGS"
+            CPPFLAGS="$CPPFLAGS $HIP_CPPFLAGS"
+            LDFLAGS="$LDFLAGS $ROCM_LDFLAGS"
             AC_CHECK_HEADER([rccl/rccl.h],
             [
                 AC_CHECK_LIB([rccl], [ncclCommInitRank],

--- a/config/m4/rdmacm.m4
+++ b/config/m4/rdmacm.m4
@@ -1,0 +1,92 @@
+#
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# See file LICENSE for terms.
+#
+
+AC_DEFUN([CHECK_RDMACM],[
+AS_IF([test "x$rdmacm_checked" != "xyes"],[
+    rdmacm_happy="no"
+
+    AC_ARG_WITH([rdmacm],
+            [AS_HELP_STRING([--with-rdmacm=(DIR)], [Enable the use of rdmacm (default is guess).])],
+            [], [with_rdmacm=guess])
+
+    AS_IF([test "x$with_rdmacm" != "xno"],
+    [
+        save_CPPFLAGS="$CPPFLAGS"
+        save_CFLAGS="$CFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+
+        AS_IF([test ! -z "$with_rdmacm" -a "x$with_rdmacm" != "xyes" -a "x$with_rdmacm" != "xguess"],
+        [
+            AS_IF([test ! -d $with_rdmacm],
+                  [AC_MSG_ERROR([Provided "--with-rdmacm=${with_rdmacm}" location does not exist])], [])
+            check_rdmacm_dir="$with_rdmacm"
+
+        ],
+        [
+            check_rdmacm_dir="/usr"
+        ]
+        )
+
+        AS_IF([test -d "$check_rdmacm_dir/lib64"],[libsuff="64"],[libsuff=""])
+
+        check_rdmacm_libdir="$check_rdmacm_dir/lib$libsuff"
+        CPPFLAGS="-I$check_rdmacm_dir/include $save_CPPFLAGS"
+        LDFLAGS="-L$check_rdmacm_libdir $save_LDFLAGS"
+
+        AC_CHECK_HEADER([$check_rdmacm_dir/include/rdma/rdma_cma.h],
+        [
+            AC_CHECK_LIB([rdmacm], [rdma_establish],
+            [
+                rdmacm_happy="yes"
+            ],
+            [
+                rdmacm_happy="no"
+            ])
+        ],
+        [
+            AC_MSG_WARN([rdmacm header files not found])
+            rdmacm_happy=no
+        ])
+
+
+        AS_IF([test "x$rdmacm_happy" = "xyes"],
+        [
+            AS_IF([test "x$check_rdmacm_dir" != "x"],
+            [
+                AC_MSG_RESULT([rdmacm dir: $check_rdmacm_dir])
+                AC_SUBST(RDMACM_CPPFLAGS, "-I$check_rdmacm_dir/include/")
+            ])
+
+            AS_IF([test "x$check_rdmacm_libdir" != "x"],
+            [
+                AC_SUBST(RDMACM_LDFLAGS, "-L$check_rdmacm_libdir")
+            ])
+
+            AC_SUBST(RDMACM_LIBADD, "-lrdmacm")
+            AC_DEFINE([HAVE_RDMACM], [1], [rdmacm support])
+        ],
+        [
+            AS_IF([test "x$with_rdmacm" != "xguess"],
+            [
+                AC_MSG_ERROR([rdmacm support is requested but rdmacm packages cannot be found $CPPFLAGS $LDFLAGS])
+            ],
+            [
+                AC_MSG_WARN([rdmacm not found])
+            ])
+        ])
+
+        CFLAGS="$save_CFLAGS"
+        CPPFLAGS="$save_CPPFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+
+    ],
+    [
+        AC_MSG_WARN([rdmacm was explicitly disabled])
+    ])
+
+    rdmacm_checked=yes
+    AM_CONDITIONAL([HAVE_RDMACM], [test "x$rdmacm_happy" != xno])
+])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      AM_CONDITIONAL([HAVE_MPICXX], [false])
      AM_CONDITIONAL([HAVE_PROFILING],[false])
      AM_CONDITIONAL([HAVE_IBVERBS],[false])
+     AM_CONDITIONAL([HAVE_RDMACM],[false])
      AM_CONDITIONAL([HAVE_MLX5DV],[false])
     ],
     [
@@ -175,6 +176,7 @@ AS_IF([test "x$with_docs_only" = xyes],
      m4_include([config/m4/sharp.m4])
      m4_include([config/m4/mpi.m4])
      m4_include([config/m4/ibverbs.m4])
+     m4_include([config/m4/rdmacm.m4])
      m4_include([config/m4/configure.m4])
      m4_include([config/m4/tl_coll_plugins.m4])
      m4_include([config/m4/check_tls.m4])
@@ -208,6 +210,9 @@ AS_IF([test "x$with_docs_only" = xyes],
 
      CHECK_IBVERBS
      AC_MSG_RESULT([IBVERBS support: $ibverbs_happy, MLX5DV support: $mlx5dv_happy])
+
+     CHECK_RDMACM
+     AC_MSG_RESULT([RDMACM support: $rdmacm_happy])
      ]) # Docs only
 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,7 @@ noinst_HEADERS =                      \
 	coll_score/ucc_coll_score.h       \
 	utils/arch/aarch64/cpu.h          \
 	utils/arch/ppc64/cpu.h            \
+	utils/arch/riscv64/cpu.h          \
 	utils/arch/x86_64/cpu.h           \
 	utils/arch/cpu.h                  \
 	utils/arch/cuda_def.h             \

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -239,7 +239,8 @@ static inline ucc_rank_t ucc_kn_get_opt_radix(ucc_rank_t team_size,
     ucc_rank_t     n_extra = 0, min_val = team_size;
     ucc_kn_radix_t min_i   = UCC_KN_MIN_RADIX;
     ucc_kn_radix_t max_r   = ucc_max(max_radix, UCC_KN_MIN_RADIX);
-    ucc_kn_radix_t r, fs;
+    ucc_kn_radix_t r;
+    ucc_rank_t     fs;
 
     for (r = UCC_KN_MIN_RADIX; r <= max_r; r++) {
         fs = r;

--- a/src/coll_patterns/recursive_knomial.h
+++ b/src/coll_patterns/recursive_knomial.h
@@ -192,6 +192,12 @@ ucc_knomial_pattern_next_iteration(ucc_knomial_pattern_t *p)
     p->radix_pow *= p->radix;
 }
 
+static inline void ucc_knomial_pattern_prev_iteration(ucc_knomial_pattern_t *p)
+{
+    p->iteration--;
+    p->radix_pow /= p->radix;
+}
+
 static inline void
 ucc_knomial_pattern_next_iteration_backward(ucc_knomial_pattern_t *p)
 {

--- a/src/components/ec/cpu/ec_cpu_reduce.c
+++ b/src/components/ec/cpu/ec_cpu_reduce.c
@@ -114,7 +114,7 @@
             break;                                                             \
         default:                                                               \
             ec_error(&ucc_ec_cpu.super,                                        \
-                     "float dtype does not support "                           \
+                     "int dtype does not support "                             \
                      "requested reduce op: %s",                                \
                      ucc_reduction_op_str(_op));                               \
             return UCC_ERR_NOT_SUPPORTED;                                      \

--- a/src/components/ec/cuda/ec_cuda.h
+++ b/src/components/ec/cuda/ec_cuda.h
@@ -127,20 +127,4 @@ extern ucc_ec_cuda_t ucc_ec_cuda;
 #define EC_CUDA_CONFIG                                                         \
     (ucc_derived_of(ucc_ec_cuda.super.config, ucc_ec_cuda_config_t))
 
-#define UCC_EC_CUDA_INIT_STREAM() do {                                         \
-    if (!ucc_ec_cuda.stream_initialized) {                                     \
-        cudaError_t cuda_st = cudaSuccess;                                     \
-        ucc_spin_lock(&ucc_ec_cuda.init_spinlock);                             \
-        if (!ucc_ec_cuda.stream_initialized) {                                 \
-            cuda_st = cudaStreamCreateWithFlags(&ucc_ec_cuda.stream,           \
-                                                cudaStreamNonBlocking);        \
-            ucc_ec_cuda.stream_initialized = 1;                                \
-        }                                                                      \
-        ucc_spin_unlock(&ucc_ec_cuda.init_spinlock);                           \
-        if (ucc_unlikely(cudaSuccess != cuda_st)) {                            \
-            return cuda_error_to_ucc_status(cuda_st);                          \
-        }                                                                      \
-    }                                                                          \
-} while(0)
-
 #endif

--- a/src/components/ec/cuda/kernel/ec_cuda_half_sm52.h
+++ b/src/components/ec/cuda/kernel/ec_cuda_half_sm52.h
@@ -11,7 +11,8 @@
  * We copy-pasted and modify cuda_fp16.hpp because half operators are only available
  * for SM>=5.3 but we need to support earlier architectures. On earlier architectures,
  * we emulate the operators by converting half to float, do the operation, then convert
- * the result back to half
+ * the result back to half.
+ * Since CUDA 12.2 similar functionality was added to cuda_fp16.hpp
  */
 
 #pragma once
@@ -23,7 +24,7 @@
 
 /* Arithmetic FP16 operations in cuda_fp16.hpp only supported on arch >= 5.3,
  * however, we support early architectures*/
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 530)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 530) && (CUDA_VERSION < 12020)
 #if !defined(__CUDA_NO_HALF_OPERATORS__)
 
 /* Some basic arithmetic operations expected of a builtin */

--- a/src/components/mc/base/ucc_mc_base.h
+++ b/src/components/mc/base/ucc_mc_base.h
@@ -100,7 +100,8 @@ extern ucc_config_field_t ucc_mc_config_table[];
 
 typedef struct ucc_mc_ops {
     ucc_status_t (*mem_query)(const void *ptr, ucc_mem_attr_t *mem_attr);
-    ucc_status_t (*mem_alloc)(ucc_mc_buffer_header_t **h_ptr, size_t size);
+    ucc_status_t (*mem_alloc)(ucc_mc_buffer_header_t **h_ptr, size_t size,
+                              ucc_memory_type_t mt);
     ucc_status_t (*mem_free)(ucc_mc_buffer_header_t *h_ptr);
     ucc_status_t (*memcpy)(void *dst, const void *src, size_t len,
                            ucc_memory_type_t dst_mem,

--- a/src/components/mc/cuda/mc_cuda.c
+++ b/src/components/mc/cuda/mc_cuda.c
@@ -226,7 +226,7 @@ static ucc_status_t ucc_mc_cuda_mem_free(ucc_mc_buffer_header_t *h_ptr)
         mc_error(&ucc_mc_cuda.super,
                  "failed to free mem at %p, "
                  "cuda error %d(%s)",
-                 h_ptr->addr, st, cudaGetErrorString(st));
+                 h_ptr, st, cudaGetErrorString(st));
         return UCC_ERR_NO_MESSAGE;
     }
     ucc_free(h_ptr);

--- a/src/components/mc/cuda/mc_cuda.h
+++ b/src/components/mc/cuda/mc_cuda.h
@@ -47,10 +47,12 @@ extern ucc_mc_cuda_t ucc_mc_cuda;
             ucc_mc_cuda.stream_initialized = 1;                                \
         }                                                                      \
         ucc_spin_unlock(&ucc_mc_cuda.init_spinlock);                           \
-        if (ucc_unlikely(cudaSuccess != cuda_st)) {                     \
-            return cuda_error_to_ucc_status(cuda_st);                   \
-        }                                                               \
+        if (ucc_unlikely(cudaSuccess != cuda_st)) {                            \
+            return cuda_error_to_ucc_status(cuda_st);                          \
+        }                                                                      \
     }                                                                          \
 } while(0)
+
+ucc_status_t ucc_mc_cuda_memset(void *ptr, int val, size_t len);
 
 #endif

--- a/src/components/tl/cuda/allgatherv/allgatherv_linear.c
+++ b/src/components/tl/cuda/allgatherv/allgatherv_linear.c
@@ -131,7 +131,7 @@ static inline ucc_status_t ecopy(void *dst, void *src, size_t size,
                                  ucc_ee_executor_t *      exec,
                                  ucc_ee_executor_task_t **etask)
 {
-    ucc_ee_executor_task_args_t exec_args;
+    ucc_ee_executor_task_args_t exec_args = {0};
 
     exec_args.task_type = UCC_EE_EXECUTOR_TASK_COPY;
     exec_args.copy.dst  = dst;

--- a/src/components/tl/cuda/alltoallv/alltoallv_ce.c
+++ b/src/components/tl/cuda/alltoallv/alltoallv_ce.c
@@ -146,9 +146,10 @@ exit_err:
 
 ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
 {
-    ucc_tl_cuda_team_t         *team = TASK_TEAM(task);
-    ucc_rank_t                  rank = UCC_TL_TEAM_RANK(team);
-    ucc_tl_cuda_sync_t         *sync = TASK_SYNC(task, rank);
+    ucc_tl_cuda_team_t         *team      = TASK_TEAM(task);
+    ucc_rank_t                  rank      = UCC_TL_TEAM_RANK(team);
+    ucc_tl_cuda_sync_t         *sync      = TASK_SYNC(task, rank);
+    ucc_ee_executor_task_args_t exec_args = {0};
     ucc_tl_cuda_sync_t         *peer_sync;
     ucc_ee_executor_t          *exec;
     void                       *src, *dst;
@@ -156,7 +157,6 @@ ucc_status_t ucc_tl_cuda_alltoallv_ce_post_copies(ucc_tl_cuda_task_t *task)
     size_t                      data_size, data_displ;
     ucc_rank_t                  i, peer, psrc, pdst;
     ucc_status_t                status;
-    ucc_ee_executor_task_args_t exec_args;
 
     task->alltoallv_ce.num_posted = 0;
     status = ucc_coll_task_get_executor(&task->super, &exec);

--- a/src/components/tl/cuda/tl_cuda_cache.c
+++ b/src/components/tl/cuda/tl_cuda_cache.c
@@ -280,6 +280,7 @@ ucc_tl_cuda_map_memhandle(const void *d_ptr, size_t size,
 
 err:
     pthread_rwlock_unlock(&cache->lock);
+    // coverity[leaked_storage:FALSE]
     return status;
 
 

--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -12,11 +12,15 @@ alltoall =                      \
 	alltoall/alltoall_inline.h  \
 	alltoall/alltoall_coll.c
 
-mcast =                           \
-	mcast/tl_mlx5_mcast_context.c \
-	mcast/tl_mlx5_mcast.h         \
-	mcast/tl_mlx5_mcast_coll.c    \
-	mcast/tl_mlx5_mcast_coll.h    \
+mcast =                                 \
+	mcast/tl_mlx5_mcast_context.c       \
+	mcast/tl_mlx5_mcast.h               \
+	mcast/tl_mlx5_mcast_coll.c          \
+	mcast/tl_mlx5_mcast_coll.h          \
+	mcast/tl_mlx5_mcast_rcache.h        \
+	mcast/tl_mlx5_mcast_rcache.c        \
+	mcast/p2p/ucc_tl_mlx5_mcast_p2p.h   \
+	mcast/p2p/ucc_tl_mlx5_mcast_p2p.c   \
 	mcast/tl_mlx5_mcast_team.c
 
 sources =             \

--- a/src/components/tl/mlx5/Makefile.am
+++ b/src/components/tl/mlx5/Makefile.am
@@ -4,11 +4,13 @@
 
 if TL_MLX5_ENABLED
 
-alltoall =                    \
-	alltoall/alltoall.h       \
-	alltoall/alltoall.c       \
-	alltoall/alltoall_mkeys.h \
-	alltoall/alltoall_mkeys.c
+alltoall =                      \
+	alltoall/alltoall.h         \
+	alltoall/alltoall.c         \
+	alltoall/alltoall_mkeys.h   \
+	alltoall/alltoall_mkeys.c   \
+	alltoall/alltoall_inline.h  \
+	alltoall/alltoall_coll.c
 
 mcast =                           \
 	mcast/tl_mlx5_mcast_context.c \

--- a/src/components/tl/mlx5/alltoall/alltoall.c
+++ b/src/components/tl/mlx5/alltoall/alltoall.c
@@ -523,6 +523,7 @@ ucc_tl_mlx5_team_alltoall_init_progress(ucc_tl_mlx5_team_t *tl_team)
             tl_error(UCC_TL_TEAM_LIB(tl_team),
                      "failure during service coll exchange: %s",
                      ucc_status_string(status));
+            ucc_service_coll_finalize(tl_team->scoll_req);
             goto err_service_allgather_progress;
         }
         if (UCC_INPROGRESS == status) {
@@ -652,7 +653,6 @@ err_rkeys:
     ucc_free(a2a->net.rank_map);
 err_rank_map:
 err_service_allgather_progress:
-    ucc_service_coll_finalize(tl_team->scoll_req);
 err_service_allgather_post:
     if (!a2a->is_dc) {
 err_create_rc_qps:

--- a/src/components/tl/mlx5/alltoall/alltoall.h
+++ b/src/components/tl/mlx5/alltoall/alltoall.h
@@ -9,6 +9,7 @@
 
 #include "tl_mlx5.h"
 #include "tl_mlx5_ib.h"
+#include "tl_mlx5_dm.h"
 
 #define SEQ_INDEX(_seq_num) ((_seq_num) % MAX_OUTSTANDING_OPS)
 
@@ -136,8 +137,10 @@ typedef struct ucc_tl_mlx5_alltoall {
     ucc_tl_mlx5_a2a_bcast_data_t bcast_data;
 } ucc_tl_mlx5_alltoall_t;
 
-ucc_status_t ucc_tl_mlx5_team_alltoall_init_start(ucc_tl_mlx5_team_t *team);
-ucc_status_t ucc_tl_mlx5_team_alltoall_init_progress(ucc_tl_mlx5_team_t *team);
+void         ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_init_alltoall(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_test_alltoall_start(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_test_alltoall_progress(ucc_tl_mlx5_team_t *team);
 ucc_status_t ucc_tl_mlx5_alltoall_init(ucc_base_coll_args_t *coll_args,
                                        ucc_base_team_t *     team,
                                        ucc_coll_task_t **    task_h);

--- a/src/components/tl/mlx5/alltoall/alltoall.h
+++ b/src/components/tl/mlx5/alltoall/alltoall.h
@@ -118,11 +118,9 @@ typedef struct ucc_tl_mlx5_alltoall {
     struct ibv_context          *ctx;
     int                          ib_port;
     int                          state;
-    int                          transpose;
     uint64_t                     max_msg_size;
     ucc_tl_mlx5_alltoall_node_t  node;
     ucc_tl_mlx5_alltoall_net_t   net;
-    void                        *service_bcast_tmp_buf;
     int                          sequence_number;
     int                          op_busy[MAX_OUTSTANDING_OPS];
     int                          num_dci_qps;
@@ -130,16 +128,19 @@ typedef struct ucc_tl_mlx5_alltoall {
     int                          previous_msg_size[MAX_OUTSTANDING_OPS];
     void                        *previous_send_address[MAX_OUTSTANDING_OPS];
     void                        *previous_recv_address[MAX_OUTSTANDING_OPS];
-    uint64_t                     dummy_atomic_buff;
+    uint64_t                     atomic_scratch_bf;
     int                          requested_block_size;
     int                          max_num_of_columns;
-    struct ibv_mr               *scratch_bf_mr;
+    struct ibv_mr               *atomic_scratch_bf_mr;
     ucc_rank_t                   node_size;
     ucc_tl_mlx5_a2a_bcast_data_t bcast_data;
 } ucc_tl_mlx5_alltoall_t;
 
-ucc_status_t ucc_tl_mlx5_alltoall_init_start(ucc_tl_mlx5_team_t *team);
-ucc_status_t ucc_tl_mlx5_alltoall_init_progress(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_alltoall_init_start(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_team_alltoall_init_progress(ucc_tl_mlx5_team_t *team);
+ucc_status_t ucc_tl_mlx5_alltoall_init(ucc_base_coll_args_t *coll_args,
+                                       ucc_base_team_t *     team,
+                                       ucc_coll_task_t **    task_h);
 void         ucc_tl_mlx5_alltoall_cleanup(ucc_tl_mlx5_team_t *team);
 
 static inline ucc_tl_mlx5_alltoall_ctrl_t*

--- a/src/components/tl/mlx5/alltoall/alltoall_coll.c
+++ b/src/components/tl/mlx5/alltoall/alltoall_coll.c
@@ -1,0 +1,914 @@
+/**
+ * Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_mlx5_coll.h"
+#include "alltoall/alltoall.h"
+#include "alltoall/alltoall_mkeys.h"
+#include "alltoall/alltoall_inline.h"
+
+#include "components/mc/ucc_mc.h"
+#include "core/ucc_team.h"
+#include "tl_mlx5_wqe.h"
+#include "tl_mlx5_ib.h"
+
+static ucc_status_t
+ucc_tl_mlx5_poll_free_op_slot_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task      = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team      = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a       = team->a2a;
+    int                     seq_index = task->alltoall.seq_index;
+
+    if (a2a->op_busy[seq_index] && !task->alltoall.started) {
+        tl_debug(
+            UCC_TL_TEAM_LIB(team),
+            "Operation num %d must wait for previous outstanding to complete",
+            task->alltoall.seq_num);
+    }
+
+    coll_task->status       = UCC_INPROGRESS;
+    coll_task->super.status = UCC_INPROGRESS;
+    ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, coll_task);
+    return UCC_OK;
+}
+
+void ucc_tl_mlx5_poll_free_op_slot_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task      = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team      = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a       = team->a2a;
+    int                     seq_index = task->alltoall.seq_index;
+
+    if (a2a->op_busy[seq_index] && !task->alltoall.started) {
+        coll_task->status = UCC_INPROGRESS;
+        return;
+    } //wait for slot to be open
+    a2a->op_busy[seq_index] = 1;
+    task->alltoall.started  = 1;
+    coll_task->status       = UCC_OK;
+    tl_debug(UCC_TL_TEAM_LIB(team), "Operation num %d started",
+             task->alltoall.seq_num);
+}
+
+static ucc_status_t ucc_tl_mlx5_poll_cq(struct ibv_cq *cq, ucc_base_lib_t *lib)
+{
+    int           i, completions_num;
+    struct ibv_wc wcs[MIN_POLL_WC];
+
+    completions_num = ibv_poll_cq(cq, MIN_POLL_WC, wcs);
+    if (completions_num < 0) {
+        tl_error(lib, "ibv_poll_cq() failed, errno %d", errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+    for (i = 0; i < completions_num; i++) {
+        if (wcs[i].status != IBV_WC_SUCCESS) {
+            tl_error(lib, "bad work completion status %s, wr_id %zu",
+                     ibv_wc_status_str(wcs[i].status), wcs[i].wr_id);
+            return UCC_ERR_NO_MESSAGE;
+        }
+
+        ucc_assert(wcs[i].opcode == IBV_WC_DRIVER2);
+        if (wcs[i].wr_id == 0) {
+            /* signalled transpose */
+            continue;
+        } else if (wcs[i].wr_id & 0x1) {
+            ucc_tl_mlx5_schedule_t *task =
+                (ucc_tl_mlx5_schedule_t *)(uintptr_t)(wcs[i].wr_id &
+                                                      (~(uint64_t)0x1));
+            task->alltoall.wait_wc = 1;
+        } else {
+            ucc_tl_mlx5_dm_chunk_t *dm = (ucc_tl_mlx5_dm_chunk_t *)wcs[i].wr_id;
+            dm->task->alltoall.blocks_completed++;
+            ucc_mpool_put(dm);
+        }
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_tl_mlx5_node_fanin(ucc_tl_mlx5_team_t     *team,
+                                           ucc_tl_mlx5_schedule_t *task)
+{
+    ucc_tl_mlx5_alltoall_t      *a2a       = team->a2a;
+    int                          seq_index = task->alltoall.seq_index;
+    int                          i;
+    ucc_tl_mlx5_alltoall_ctrl_t *ctrl_v;
+
+    if (a2a->node.sbgp->group_rank != a2a->node.asr_rank) {
+        ucc_tl_mlx5_get_my_ctrl(a2a, seq_index)->seq_num =
+            task->alltoall.seq_num;
+    } else {
+        for (i = 0; i < a2a->node.sbgp->group_size; i++) {
+            if (i == a2a->node.sbgp->group_rank) {
+                continue;
+            }
+            ctrl_v = ucc_tl_mlx5_get_ctrl(a2a, seq_index, i);
+            if (ctrl_v->seq_num != task->alltoall.seq_num) {
+                return UCC_INPROGRESS;
+            }
+        }
+        for (i = 0; i < a2a->node.sbgp->group_size; i++) {
+            if (i == a2a->node.sbgp->group_rank) {
+                continue;
+            }
+            ctrl_v = ucc_tl_mlx5_get_ctrl(a2a, seq_index, i);
+            ucc_tl_mlx5_get_my_ctrl(a2a, seq_index)->mkey_cache_flag |=
+                ctrl_v->mkey_cache_flag;
+        }
+    }
+    UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_fanin_done", 0);
+    return UCC_OK;
+}
+
+/* Each rank registers sbuf and rbuf and place the registration data
+   in the shared memory location. Next, all rank in node nitify the
+   ASR the registration data is ready using SHM Fanin */
+static ucc_status_t ucc_tl_mlx5_reg_fanin_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t      *task            = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t          *team            = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_context_t       *ctx             = UCC_TL_MLX5_TEAM_CTX(team);
+    ucc_tl_mlx5_alltoall_t      *a2a             = team->a2a;
+    int                          reg_change_flag = 0;
+    int                          seq_index       = task->alltoall.seq_index;
+    int                          flag;
+    ucc_tl_mlx5_rcache_region_t *send_ptr;
+    ucc_tl_mlx5_rcache_region_t *recv_ptr;
+
+    UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_fanin_start", 0);
+    tl_debug(UCC_TASK_LIB(task), "register memory buffers");
+    coll_task->status       = UCC_INPROGRESS;
+    coll_task->super.status = UCC_INPROGRESS;
+
+    errno = 0;
+    if (UCC_OK !=
+        ucc_rcache_get(ctx->rcache, (void *)SCHEDULE_ARGS(task).src.info.buffer,
+                       task->alltoall.msg_size * UCC_TL_TEAM_SIZE(team),
+                       &reg_change_flag, (ucc_rcache_region_t **)&send_ptr)) {
+        tl_error(UCC_TASK_LIB(task),
+                 "Failed to register send_bf memory (errno=%d)", errno);
+        return UCC_ERR_NO_RESOURCE;
+    }
+    task->alltoall.send_rcache_region_p = send_ptr;
+
+    /* NOTE: we don't support alternating block_size for the same msg size - TODO
+       Will need to add the possibility of block_size change into consideration
+       when initializing the mkey_cache_flag */
+
+    flag =
+        (task->alltoall.msg_size == a2a->previous_msg_size[seq_index])
+            ? 0
+            : (UCC_MLX5_NEED_SEND_MKEY_UPDATE | UCC_MLX5_NEED_RECV_MKEY_UPDATE);
+
+    if (reg_change_flag || (task->alltoall.send_rcache_region_p->reg.mr->addr !=
+                            a2a->previous_send_address[seq_index])) {
+        flag |= UCC_MLX5_NEED_SEND_MKEY_UPDATE;
+    }
+    reg_change_flag = 0;
+    if (UCC_OK !=
+        ucc_rcache_get(ctx->rcache, (void *)SCHEDULE_ARGS(task).dst.info.buffer,
+                       task->alltoall.msg_size * UCC_TL_TEAM_SIZE(team),
+                       &reg_change_flag, (ucc_rcache_region_t **)&recv_ptr)) {
+        tl_error(UCC_TASK_LIB(task), "Failed to register receive_bf memory");
+        ucc_rcache_region_put(ctx->rcache,
+                              &task->alltoall.send_rcache_region_p->super);
+        return UCC_ERR_NO_RESOURCE;
+    }
+    task->alltoall.recv_rcache_region_p = recv_ptr;
+    if (reg_change_flag || (task->alltoall.recv_rcache_region_p->reg.mr->addr !=
+                            a2a->previous_recv_address[seq_index])) {
+        flag |= UCC_MLX5_NEED_RECV_MKEY_UPDATE;
+    }
+
+    tl_debug(UCC_TL_MLX5_TEAM_LIB(team), "fanin start");
+    /* start task if completion event received */
+    /* Start fanin */
+    ucc_tl_mlx5_get_my_ctrl(a2a, seq_index)->mkey_cache_flag = flag;
+    ucc_tl_mlx5_update_mkeys_entries(a2a, task, flag);
+
+    if (UCC_OK == ucc_tl_mlx5_node_fanin(team, task)) {
+        tl_debug(UCC_TL_MLX5_TEAM_LIB(team), "fanin complete");
+        coll_task->status = UCC_OK;
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_fanin_done", 0);
+        return ucc_task_complete(coll_task);
+    }
+
+    ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, coll_task);
+    return UCC_OK;
+}
+
+void ucc_tl_mlx5_reg_fanin_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team = SCHEDULE_TEAM(task);
+
+    ucc_assert(team->a2a->node.sbgp->group_rank == team->a2a->node.asr_rank);
+    if (UCC_OK == ucc_tl_mlx5_node_fanin(team, task)) {
+        tl_debug(UCC_TL_MLX5_TEAM_LIB(team), "fanin complete");
+        coll_task->status = UCC_OK;
+    }
+}
+
+static ucc_status_t ucc_tl_mlx5_node_fanout(ucc_tl_mlx5_team_t     *team,
+                                            ucc_tl_mlx5_schedule_t *task)
+{
+    ucc_tl_mlx5_alltoall_t      *a2a = team->a2a;
+    ucc_tl_mlx5_alltoall_ctrl_t *ctrl_v;
+    /* First phase of fanout: asr signals it completed local ops
+       and other ranks wait for asr */
+    if (a2a->node.sbgp->group_rank == a2a->node.asr_rank) {
+        /* no need to check counter - we wait on data in device */
+        ucc_tl_mlx5_get_my_ctrl(a2a, task->alltoall.seq_index)->seq_num =
+            task->alltoall.seq_num;
+    } else {
+        ctrl_v = ucc_tl_mlx5_get_ctrl(a2a, task->alltoall.seq_index,
+                                      a2a->node.asr_rank);
+        if (ctrl_v->seq_num != task->alltoall.seq_num) {
+            return UCC_INPROGRESS;
+        }
+    }
+    return UCC_OK;
+}
+
+static ucc_status_t ucc_tl_mlx5_fanout_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team = SCHEDULE_TEAM(task);
+
+    coll_task->status       = UCC_INPROGRESS;
+    coll_task->super.status = UCC_INPROGRESS;
+
+    tl_debug(UCC_TASK_LIB(task), "fanout start");
+    /* start task if completion event received */
+    UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_fanout_start", 0);
+    /* Start fanout */
+    ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, coll_task);
+    return UCC_OK;
+}
+
+static void ucc_tl_mlx5_fanout_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a  = team->a2a;
+    ucc_status_t            status;
+
+    if (a2a->node.sbgp->group_rank == a2a->node.asr_rank) {
+        status = ucc_tl_mlx5_poll_cq(a2a->net.umr_cq, UCC_TASK_LIB(task));
+        if (UCC_OK != status) {
+            coll_task->status = status;
+            return;
+        }
+        if (!task->alltoall.wait_wc) {
+            coll_task->status = UCC_INPROGRESS;
+            return;
+        }
+    }
+
+    if (UCC_OK == ucc_tl_mlx5_node_fanout(team, task)) {
+        /*Cleanup alg resources - all done */
+        tl_debug(UCC_TASK_LIB(task), "Algorithm completion");
+        a2a->op_busy[task->alltoall.seq_index] = 0;
+        coll_task->status                      = UCC_OK;
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_fanout_done", 0);
+    }
+}
+
+static ucc_status_t ucc_tl_mlx5_asr_barrier_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task  = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team  = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a   = team->a2a;
+    tl_mlx5_barrier_t      *local = tl_mlx5_barrier_local_addr(task);
+    ucc_status_t            status;
+    int                     i;
+
+    coll_task->status       = UCC_INPROGRESS;
+    coll_task->super.status = UCC_INPROGRESS;
+
+    task->alltoall.started = 0;
+    UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_barrier_start", 0);
+    // despite while statement in poll_umr_cq, non blocking because have independent cq,
+    // will be finished in a finite time
+    ucc_tl_mlx5_populate_send_recv_mkeys(team, task);
+
+    //Reset atomic notification counter to 0
+#if ATOMIC_IN_MEMIC
+    tl_mlx5_atomic_t zero = 0;
+    if (0 !=
+        ibv_memcpy_to_dm(a2a->net.atomic.counters,
+                         task->alltoall.seq_index * sizeof(tl_mlx5_atomic_t),
+                         &zero, sizeof(tl_mlx5_atomic_t))) {
+        tl_error(UCC_TASK_LIB(task), "failed to reset atomic in memic");
+        return UCC_ERR_NO_MESSAGE;
+    }
+#else
+    a2a->net.atomic.counters[task->alltoall.seq_index] = 0;
+#endif
+    if (UCC_TL_MLX5_TEAM_LIB(team)->cfg.asr_barrier) {
+        tl_debug(UCC_TASK_LIB(task), "asr barrier start");
+        status = ucc_service_allreduce(
+            UCC_TL_CORE_TEAM(team), &task->alltoall.barrier_scratch[0],
+            &task->alltoall.barrier_scratch[1], UCC_DT_INT32, 1, UCC_OP_SUM,
+            ucc_sbgp_to_subset(a2a->net.sbgp), &task->alltoall.barrier_req);
+        if (status < 0) {
+            tl_error(UCC_TASK_LIB(task), "failed to start asr barrier");
+        }
+        for (i = 0; i < a2a->net.net_size; i++) {
+            task->alltoall.op->blocks_sent[i] = 0;
+            a2a->net.barrier
+                .flags[(a2a->net.net_size + 1) * task->alltoall.seq_index + i] =
+                task->alltoall.seq_num;
+        }
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, coll_task);
+    } else {
+        *local = task->alltoall.seq_num;
+        for (i = 0; i < a2a->net.net_size; i++) {
+            task->alltoall.op->blocks_sent[i] = 0;
+            if (i == a2a->net.sbgp->group_rank) {
+                tl_mlx5_barrier_flag_set(task, i);
+                continue;
+            }
+
+            send_start(team, i);
+            status = send_block_data(
+                a2a, i, (uintptr_t)local, sizeof(tl_mlx5_barrier_t),
+                a2a->net.barrier.mr->lkey,
+                tl_mlx5_barrier_my_remote_addr(task, i),
+                tl_mlx5_barrier_remote_rkey(task, i), 0, NULL);
+            if (UCC_OK == status) {
+                status = send_done(team, i);
+            }
+            if (status != UCC_OK) {
+                tl_error(UCC_TASK_LIB(task), "failed  sending barrier notice");
+                return status;
+            }
+        }
+        coll_task->status = UCC_OK;
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_barreir_done",
+                                          0);
+        return ucc_task_complete(coll_task);
+    }
+    return UCC_OK;
+}
+
+static void ucc_tl_mlx5_asr_barrier_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task = TASK_SCHEDULE(coll_task);
+    ucc_status_t            status;
+
+    status = ucc_collective_test(&task->alltoall.barrier_req->task->super);
+    if (status < 0) {
+        tl_error(UCC_TASK_LIB(task), "failure during asr barrier");
+    } else if (UCC_OK == status) {
+        tl_debug(UCC_TASK_LIB(task), "asr barrier done");
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_barreir_done",
+                                          0);
+        ucc_service_coll_finalize(task->alltoall.barrier_req);
+        coll_task->status = UCC_OK;
+    }
+}
+
+// add polling mechanism for blocks in order to maintain const qp tx rx
+static ucc_status_t ucc_tl_mlx5_send_blocks_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task           = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team           = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a            = team->a2a;
+    int                     node_size      = a2a->node.sbgp->group_size;
+    int                     net_size       = a2a->net.sbgp->group_size;
+    int                     op_msgsize     = node_size * a2a->max_msg_size
+                                                     * UCC_TL_TEAM_SIZE(team)
+                                                     * a2a->max_num_of_columns;
+    int                     node_msgsize   = SQUARED(node_size)
+                                                     * task->alltoall.msg_size;
+    int                     block_size     = task->alltoall.block_size;
+    int                     col_msgsize    = task->alltoall.msg_size
+                                                      * block_size * node_size;
+    int                     block_msgsize  = SQUARED(block_size)
+                                                     * task->alltoall.msg_size;
+    int                     dm_host        = UCC_TL_MLX5_TEAM_LIB(team)
+                                                                 ->cfg.dm_host;
+    ucc_status_t            status         = UCC_OK;
+    ucc_base_lib_t         *lib            = UCC_TASK_LIB(task);
+    int                     seq_index      = task->alltoall.seq_index;
+    int                     i, j, k, rank, dest_rank, cyc_rank;
+    uint64_t                src_addr, remote_addr;
+    ucc_tl_mlx5_dm_chunk_t *dm;
+    uintptr_t               dm_addr;
+
+    coll_task->status       = UCC_INPROGRESS;
+    coll_task->super.status = UCC_INPROGRESS;
+
+    tl_debug(lib, "send blocks start");
+    rank = a2a->net.rank_map[a2a->net.sbgp->group_rank];
+    if (!task->alltoall.send_blocks_enqueued) {
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task,
+                                          "mlx5_alltoall_block_send_start", 0);
+    }
+
+    for (i = 0; i < net_size; i++) {
+        cyc_rank  = (i + a2a->net.sbgp->group_rank) % net_size;
+        dest_rank = a2a->net.rank_map[cyc_rank];
+        if (task->alltoall.op->blocks_sent[cyc_rank] ||
+            tl_mlx5_barrier_flag(task, cyc_rank) != task->alltoall.seq_num) {
+            continue;
+        }
+
+        //send all blocks from curr node to some ARR
+        for (j = 0; j < (node_size / block_size); j++) {
+            for (k = 0; k < (node_size / block_size); k++) {
+                src_addr = (uintptr_t)(node_msgsize * dest_rank +
+                                       col_msgsize * j + block_msgsize * k);
+                remote_addr =
+                    (uintptr_t)(op_msgsize * seq_index + node_msgsize * rank +
+                                block_msgsize * j + col_msgsize * k);
+
+                send_start(team, cyc_rank);
+                if (cyc_rank == a2a->net.sbgp->group_rank) {
+                    status = ucc_tl_mlx5_post_transpose(
+                        tl_mlx5_get_qp(a2a, cyc_rank),
+                        a2a->node.ops[seq_index].send_mkeys[0]->lkey,
+                        a2a->net.rkeys[cyc_rank], src_addr, remote_addr,
+                        task->alltoall.msg_size, block_size, block_size,
+                        (j == 0 && k == 0) ? IBV_SEND_SIGNALED : 0);
+                    if (UCC_OK != status) {
+                        return status;
+                    }
+                } else {
+                    dm = ucc_mpool_get(&team->dm_pool);
+                    while (!dm) {
+                        status = send_done(team, cyc_rank);
+                        if (UCC_OK != status) {
+                            return status;
+                        }
+
+                        status = ucc_tl_mlx5_poll_cq(a2a->net.cq, lib);
+                        if (UCC_OK != status) {
+                            return status;
+                        }
+                        dm = ucc_mpool_get(&team->dm_pool);
+                        send_start(team, cyc_rank);
+                    }
+                    if (dm_host) {
+                        dm_addr =
+                            (uintptr_t)PTR_OFFSET(team->dm_ptr, dm->offset);
+                    } else {
+                        dm_addr = dm->offset; // dm reg mr 0 based
+                    }
+                    dm->task = task;
+
+                    status = ucc_tl_mlx5_post_transpose(
+                        tl_mlx5_get_qp(a2a, cyc_rank),
+                        a2a->node.ops[seq_index].send_mkeys[0]->lkey,
+                        team->dm_mr->rkey, src_addr, dm_addr,
+                        task->alltoall.msg_size, block_size, block_size, 0);
+                    if (UCC_OK != status) {
+                        return status;
+                    }
+                    status = send_block_data(
+                        a2a, cyc_rank, dm_addr, block_msgsize,
+                        team->dm_mr->lkey, remote_addr,
+                        a2a->net.rkeys[cyc_rank], IBV_SEND_SIGNALED, dm);
+                    if (status != UCC_OK) {
+                        tl_error(lib, "failed sending block [%d,%d,%d]", i, j,
+                                 k);
+                        return status;
+                    }
+                }
+                status = send_done(team, cyc_rank);
+                if (status != UCC_OK) {
+                    return status;
+                }
+            }
+        }
+        send_start(team, cyc_rank);
+        status = send_atomic(a2a, cyc_rank, tl_mlx5_atomic_addr(task, cyc_rank),
+                             tl_mlx5_atomic_rkey(task, cyc_rank));
+
+        if (UCC_OK == status) {
+            status = send_done(team, cyc_rank);
+        }
+        task->alltoall.op->blocks_sent[cyc_rank] = 1;
+        task->alltoall.started++;
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(task), "Failed sending atomic to node [%d]",
+                     cyc_rank);
+            return status;
+        }
+    }
+    if (!task->alltoall.send_blocks_enqueued) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, coll_task);
+        task->alltoall.send_blocks_enqueued = 1;
+    }
+
+    if (task->alltoall.started == a2a->net.net_size) {
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(task, "mlx5_alltoall_block_send_done",
+                                          0);
+        status = ucc_tl_mlx5_post_wait_on_data(
+            a2a->net.umr_qp, a2a->net.net_size, a2a->net.atomic.mr->lkey,
+            (uintptr_t)
+#if ATOMIC_IN_MEMIC
+                PTR_OFFSET(0,
+#else
+                PTR_OFFSET(a2a->net.atomic.counters,
+#endif
+                           seq_index * sizeof(tl_mlx5_atomic_t)),
+            task);
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(
+            task, "mlx5_alltoall_block_post_wait_on_data_done", 0);
+    }
+    return status;
+}
+
+static ucc_status_t
+ucc_tl_mlx5_send_blocks_leftovers_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task      = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team      = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a       = team->a2a;
+    int                     node_size = a2a->node.sbgp->group_size;
+    int                     net_size  = a2a->net.sbgp->group_size;
+    int                     seq_index = task->alltoall.seq_index;
+    size_t                  msg_size  = task->alltoall.msg_size;
+    int op_msgsize = node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team) *
+                     a2a->max_num_of_columns;
+    int mkey_msgsize  = node_size * a2a->max_msg_size * UCC_TL_TEAM_SIZE(team);
+    int block_size    = task->alltoall.block_size;
+    int col_msgsize   = msg_size * block_size * node_size;
+    int block_msgsize = SQUARED(block_size) * msg_size;
+    int block_size_leftovers_side = node_size % block_size;
+    int col_msgsize_leftovers =
+        msg_size * block_size_leftovers_side * node_size;
+    int block_msgsize_leftovers =
+        block_size_leftovers_side * block_size * msg_size;
+    int          corner_msgsize = SQUARED(block_size_leftovers_side) * msg_size;
+    int          dm_host        = UCC_TL_MLX5_TEAM_LIB(team)->cfg.dm_host;
+    ucc_status_t status         = UCC_OK;
+    ucc_base_lib_t *lib         = UCC_TASK_LIB(coll_task);
+    int             nbc         = task->alltoall.num_of_blocks_columns;
+
+    int i, j, k, dest_rank, rank, cyc_rank, current_block_msgsize, bs_x, bs_y;
+    uint64_t                src_addr, remote_addr;
+    ucc_tl_mlx5_dm_chunk_t *dm;
+    uintptr_t               dm_addr;
+
+    coll_task->status       = UCC_INPROGRESS;
+    coll_task->super.status = UCC_INPROGRESS;
+
+    tl_debug(UCC_TASK_LIB(task), "send blocks start");
+    rank = a2a->net.rank_map[a2a->net.sbgp->group_rank];
+
+    for (i = 0; i < net_size; i++) {
+        cyc_rank  = (i + a2a->net.sbgp->group_rank) % net_size;
+        dest_rank = a2a->net.rank_map[cyc_rank];
+        if (task->alltoall.op->blocks_sent[cyc_rank] ||
+            tl_mlx5_barrier_flag(task, cyc_rank) != task->alltoall.seq_num) {
+            continue;
+        }
+        //send all blocks from curr node to some ARR
+        for (j = 0; j < nbc; j++) {
+            for (k = 0; k < nbc; k++) {
+                if (j != (nbc - 1)) {
+                    src_addr = (uintptr_t)(col_msgsize * dest_rank +
+                                           block_msgsize * k);
+                } else {
+                    src_addr = (uintptr_t)(col_msgsize_leftovers * dest_rank +
+                                           block_msgsize_leftovers * k);
+                }
+                if (k != (nbc - 1)) {
+                    remote_addr = (uintptr_t)(
+                        op_msgsize * seq_index + col_msgsize * rank +
+                        block_msgsize * j + mkey_msgsize * k);
+                    current_block_msgsize = (j != (nbc - 1))
+                                                ? block_msgsize
+                                                : block_msgsize_leftovers;
+                } else {
+                    remote_addr = (uintptr_t)(
+                        op_msgsize * seq_index + col_msgsize_leftovers * rank +
+                        block_msgsize_leftovers * j + mkey_msgsize * k);
+                    current_block_msgsize = (j != (nbc - 1))
+                                                ? block_msgsize_leftovers
+                                                : corner_msgsize;
+                }
+                bs_x = k < nbc - 1 ? block_size : block_size_leftovers_side;
+                bs_y = j < nbc - 1 ? block_size : block_size_leftovers_side;
+
+                send_start(team, cyc_rank);
+
+                //todo : start/end for RC ?
+                if (bs_x == 1 || bs_y == 1) {
+                    status = send_block_data(
+                        a2a, cyc_rank, src_addr, current_block_msgsize,
+                        a2a->node.ops[seq_index].send_mkeys[j]->lkey,
+                        remote_addr, a2a->net.rkeys[cyc_rank], 0, NULL);
+                } else {
+                    dm = ucc_mpool_get(&team->dm_pool);
+                    while (!dm) {
+                        status = send_done(team, cyc_rank);
+                        if (UCC_OK != status) {
+                            return status;
+                        }
+
+                        status = ucc_tl_mlx5_poll_cq(a2a->net.cq, lib);
+                        if (UCC_OK != status) {
+                            return status;
+                        }
+                        dm = ucc_mpool_get(&team->dm_pool);
+                        send_start(team, cyc_rank);
+                    }
+                    if (dm_host) {
+                        dm_addr =
+                            (uintptr_t)PTR_OFFSET(team->dm_ptr, dm->offset);
+                    } else {
+                        dm_addr = dm->offset; // dm reg mr 0 based
+                    }
+                    dm->task = task;
+
+                    status = ucc_tl_mlx5_post_transpose(
+                        tl_mlx5_get_qp(a2a, cyc_rank),
+                        a2a->node.ops[seq_index].send_mkeys[j]->lkey,
+                        team->dm_mr->rkey, src_addr, dm_addr, msg_size, bs_x,
+                        bs_y, 0);
+                    if (UCC_OK != status) {
+                        return status;
+                    }
+
+                    status = send_block_data(
+                        a2a, cyc_rank, dm_addr, current_block_msgsize,
+                        team->dm_mr->lkey, remote_addr,
+                        a2a->net.rkeys[cyc_rank], IBV_SEND_SIGNALED, dm);
+                }
+                if (status != UCC_OK) {
+                    tl_error(UCC_TASK_LIB(task),
+                             "Failed sending block [%d,%d,%d]", i, j, k);
+                    return status;
+                }
+                status = send_done(team, cyc_rank);
+                if (UCC_OK != status) {
+                    return status;
+                }
+            }
+        }
+        send_start(team, cyc_rank);
+        status = send_atomic(a2a, cyc_rank, tl_mlx5_atomic_addr(task, cyc_rank),
+                             tl_mlx5_atomic_rkey(task, cyc_rank));
+        if (UCC_OK == status) {
+            status = send_done(team, cyc_rank);
+        }
+        task->alltoall.op->blocks_sent[cyc_rank] = 1;
+        task->alltoall.started++;
+        if (status != UCC_OK) {
+            tl_error(UCC_TASK_LIB(task), "Failed sending atomic to node [%d]",
+                     cyc_rank);
+            return status;
+        }
+    }
+    if (!task->alltoall.send_blocks_enqueued) {
+        ucc_progress_enqueue(UCC_TL_CORE_CTX(team)->pq, coll_task);
+        task->alltoall.send_blocks_enqueued = 1;
+    }
+
+    if (task->alltoall.started == a2a->net.net_size) {
+        status = ucc_tl_mlx5_post_wait_on_data(
+            a2a->net.umr_qp, a2a->net.net_size, a2a->net.atomic.mr->lkey,
+            (uintptr_t)
+#if ATOMIC_IN_MEMIC
+                PTR_OFFSET(0,
+#else
+                PTR_OFFSET(a2a->net.atomic.counters,
+#endif
+                           seq_index * sizeof(tl_mlx5_atomic_t)),
+            task);
+    }
+
+    return status;
+}
+
+static void ucc_tl_mlx5_send_blocks_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task = TASK_SCHEDULE(coll_task);
+    ucc_tl_mlx5_team_t     *team = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a  = team->a2a;
+    ucc_status_t            status;
+
+    if (task->alltoall.started != a2a->net.net_size) {
+        coll_task->post(coll_task);
+        return;
+    }
+    status = ucc_tl_mlx5_poll_cq(a2a->net.cq, UCC_TASK_LIB(coll_task));
+    if (UCC_OK != status) {
+        coll_task->status = status;
+        return;
+    }
+
+    if (task->alltoall.blocks_sent == task->alltoall.blocks_completed) {
+        UCC_TL_MLX5_PROFILE_REQUEST_EVENT(
+            task, "mlx5_alltoall_all_blocks_completed", 0);
+        coll_task->status = UCC_OK;
+    }
+}
+
+ucc_status_t ucc_tl_mlx5_alltoall_start(ucc_coll_task_t *coll_task)
+{
+    UCC_TL_MLX5_PROFILE_REQUEST_EVENT(coll_task, "mlx5_alltoall_start", 0);
+    return ucc_schedule_start(coll_task);
+}
+
+ucc_status_t ucc_tl_mlx5_alltoall_finalize(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_mlx5_schedule_t *task =
+        ucc_derived_of(coll_task, ucc_tl_mlx5_schedule_t);
+    ucc_tl_mlx5_team_t     *team      = SCHEDULE_TEAM(task);
+    ucc_tl_mlx5_alltoall_t *a2a       = team->a2a;
+    ucc_tl_mlx5_context_t  *ctx       = SCHEDULE_CTX(task);
+    int                     seq_index = task->alltoall.seq_index;
+    ucc_status_t            status;
+
+    a2a->previous_msg_size[seq_index] = task->alltoall.msg_size;
+    a2a->previous_send_address[seq_index] =
+        task->alltoall.send_rcache_region_p->reg.mr->addr;
+    a2a->previous_recv_address[seq_index] =
+        task->alltoall.recv_rcache_region_p->reg.mr->addr;
+    ucc_rcache_region_put(ctx->rcache,
+                          &task->alltoall.send_rcache_region_p->super);
+    ucc_rcache_region_put(ctx->rcache,
+                          &task->alltoall.recv_rcache_region_p->super);
+    UCC_TL_MLX5_PROFILE_REQUEST_EVENT(coll_task, "mlx5_alltoall_done", 0);
+    status = ucc_schedule_finalize(coll_task);
+    ucc_tl_mlx5_put_schedule(task);
+    return status;
+}
+
+static inline int power2(int value)
+{
+    int p = 2;
+
+    while (p < value) {
+        p *= 2;
+    }
+    return p;
+}
+
+static inline int block_size_fits(size_t msgsize, int block_size)
+{
+    return block_size * ucc_max(power2(block_size) * msgsize, MAX_MSG_SIZE) <=
+           MAX_TRANSPOSE_SIZE;
+}
+
+static inline int get_block_size(ucc_tl_mlx5_schedule_t *task)
+{
+    ucc_tl_mlx5_team_t *team              = SCHEDULE_TEAM(task);
+    int                 ppn               = team->a2a->node.sbgp->group_size;
+    size_t              effective_msgsize = power2(ucc_max(
+                                                task->alltoall.msg_size, 8));
+    int                 block_size;
+
+    block_size = ppn;
+    while (!block_size_fits(effective_msgsize, block_size)) {
+        block_size--;
+    }
+
+    return ucc_max(1, block_size);
+}
+
+UCC_TL_MLX5_PROFILE_FUNC(ucc_status_t, ucc_tl_mlx5_alltoall_init,
+                         (coll_args, team, task_h),
+                         ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
+                         ucc_coll_task_t **task_h)
+{
+    ucc_tl_mlx5_team_t     *tl_team   = ucc_derived_of(team,
+                                                           ucc_tl_mlx5_team_t);
+    ucc_tl_mlx5_alltoall_t *a2a       = tl_team->a2a;
+    int                     is_asr    = (a2a->node.sbgp->group_rank
+                                                        == a2a->node.asr_rank);
+    int                     n_tasks   = is_asr ? 5 : 3;
+    int                     curr_task = 0;
+    ucc_schedule_t         *schedule;
+    ucc_tl_mlx5_schedule_t *task;
+    size_t                  msg_size;
+    int                     block_size, i;
+    ucc_coll_task_t        *tasks[5];
+    ucc_status_t            status;
+
+    if (UCC_IS_INPLACE(coll_args->args)) {
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    msg_size = (coll_args->args.src.info.count *
+                ucc_dt_size(coll_args->args.src.info.datatype)) /
+               UCC_TL_TEAM_SIZE(tl_team);
+    if (!msg_size) {
+        tl_trace(UCC_TL_TEAM_LIB(tl_team),
+                 "msg size too short, reduces to nullop");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (msg_size > a2a->max_msg_size) {
+        tl_trace(UCC_TL_TEAM_LIB(tl_team), "msg size too long");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    status = ucc_tl_mlx5_get_schedule(tl_team, coll_args, &task);
+    if (ucc_unlikely(UCC_OK != status)) {
+        return status;
+    }
+    schedule = &task->super;
+
+    for (i = 0; i < n_tasks; i++) {
+        tasks[i] = &ucc_tl_mlx5_init_task(coll_args, team, schedule)->super;
+    }
+
+    task->alltoall.send_blocks_enqueued = 0;
+    task->alltoall.started              = 0;
+    task->alltoall.wait_wc              = 0;
+    task->alltoall.blocks_sent          = 0;
+    task->alltoall.blocks_completed     = 0;
+    task->alltoall.seq_num              = a2a->sequence_number;
+    task->alltoall.seq_index            = SEQ_INDEX(a2a->sequence_number);
+    task->alltoall.op                   = &a2a->node.ops[
+                                                     task->alltoall.seq_index];
+    task->alltoall.msg_size             = msg_size;
+
+    tl_trace(UCC_TL_TEAM_LIB(tl_team), "Seq num is %d", task->alltoall.seq_num);
+    a2a->sequence_number += 1;
+
+    block_size = a2a->requested_block_size ? a2a->requested_block_size
+                                           : get_block_size(task);
+
+    //todo following section correct assuming homogenous PPN across all nodes
+    task->alltoall.num_of_blocks_columns =
+        (a2a->node.sbgp->group_size % block_size)
+            ? ucc_div_round_up(a2a->node.sbgp->group_size, block_size)
+            : 0;
+    task->alltoall.block_size = block_size;
+
+    // TODO remove for connectX-7 - this is mkey_entry->stride (count+skip) limitation - only 16 bits
+    if (task->alltoall
+            .num_of_blocks_columns) { // for other case we will never reach limit - we use bytes skip only for the "leftovers" mode, which means when
+                                      // num_of_blocks_columns != 0
+        size_t limit =
+            (1ULL
+             << 16); // TODO We need to query this from device (or device type) and not user hardcoded values
+        size_t bytes_count, bytes_count_last, bytes_skip, bytes_skip_last;
+        int    ppn = a2a->node.sbgp->group_size;
+        int    bs  = block_size;
+
+        bytes_count_last = (ppn % bs) * msg_size;
+        bytes_skip_last  = (ppn - (ppn % bs)) * msg_size;
+        bytes_count      = bs * msg_size;
+        bytes_skip       = (ppn - bs) * msg_size;
+        if ((bytes_count + bytes_skip >= limit) ||
+            (bytes_count_last + bytes_skip_last >= limit)) {
+            tl_debug(UCC_TL_TEAM_LIB(tl_team), "unsupported operation");
+            status = UCC_ERR_NOT_SUPPORTED;
+            goto put_schedule;
+        }
+    }
+
+    ucc_schedule_add_task(schedule, tasks[0]);
+    ucc_event_manager_subscribe(&schedule->super, UCC_EVENT_SCHEDULE_STARTED,
+                                tasks[0], ucc_task_start_handler);
+    for (i = 0; i < (n_tasks - 1); i++) {
+        ucc_schedule_add_task(schedule, tasks[i + 1]);
+        ucc_event_manager_subscribe(tasks[i], UCC_EVENT_COMPLETED, tasks[i + 1],
+                                    ucc_task_start_handler);
+    }
+
+    tasks[curr_task]->post     = ucc_tl_mlx5_poll_free_op_slot_start;
+    tasks[curr_task]->progress = ucc_tl_mlx5_poll_free_op_slot_progress;
+    curr_task++;
+
+    tasks[curr_task]->post     = ucc_tl_mlx5_reg_fanin_start;
+    tasks[curr_task]->progress = ucc_tl_mlx5_reg_fanin_progress;
+    curr_task++;
+
+    if (is_asr) {
+        tasks[curr_task]->post     = ucc_tl_mlx5_asr_barrier_start;
+        tasks[curr_task]->progress = ucc_tl_mlx5_asr_barrier_progress;
+        curr_task++;
+        if (task->alltoall.num_of_blocks_columns) {
+            tasks[curr_task]->post = ucc_tl_mlx5_send_blocks_leftovers_start;
+        } else {
+            tasks[curr_task]->post = ucc_tl_mlx5_send_blocks_start;
+        }
+        tasks[curr_task]->progress = ucc_tl_mlx5_send_blocks_progress;
+        curr_task++;
+    }
+    tasks[curr_task]->post     = ucc_tl_mlx5_fanout_start;
+    tasks[curr_task]->progress = ucc_tl_mlx5_fanout_progress;
+
+    schedule->super.post           = ucc_tl_mlx5_alltoall_start;
+    schedule->super.progress       = NULL;
+    schedule->super.finalize       = ucc_tl_mlx5_alltoall_finalize;
+    schedule->super.triggered_post = NULL;
+
+    *task_h = &schedule->super;
+    return status;
+
+put_schedule:
+    ucc_tl_mlx5_put_schedule(task);
+    return status;
+}

--- a/src/components/tl/mlx5/alltoall/alltoall_inline.h
+++ b/src/components/tl/mlx5/alltoall/alltoall_inline.h
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#ifndef UCC_TL_MLX5_INLINE_H_
+#define UCC_TL_MLX5_INLINE_H_
+
+#include "tl_mlx5_ib.h"
+#include "tl_mlx5_coll.h"
+#include "tl_mlx5_wqe.h"
+#include "alltoall/alltoall.h"
+
+static inline struct ibv_qp_ex *tl_mlx5_get_qp_ex(ucc_tl_mlx5_alltoall_t *a2a,
+                                                  ucc_rank_t              rank)
+{
+    if (a2a->is_dc) {
+        return a2a->net.dcis[rank % a2a->num_dci_qps].dc_qpex;
+    }
+    return a2a->net.rc_qps[rank].qp_ex;
+}
+
+static inline struct ibv_qp *tl_mlx5_get_qp(ucc_tl_mlx5_alltoall_t *a2a,
+                                            ucc_rank_t              rank)
+{
+    if (a2a->is_dc) {
+        return a2a->net.dcis[rank % a2a->num_dci_qps].dci_qp;
+    }
+    return a2a->net.rc_qps[rank].qp;
+}
+
+static inline ucc_status_t
+send_block_data(ucc_tl_mlx5_alltoall_t *a2a, ucc_rank_t rank, uint64_t src_addr,
+                uint32_t msg_size, uint32_t lkey, uint64_t remote_addr,
+                uint32_t rkey, int send_flags, ucc_tl_mlx5_dm_chunk_t *dm)
+{
+    struct ibv_qp *qp   = tl_mlx5_get_qp(a2a, rank);
+    struct ibv_ah *ah   = NULL;
+    uint32_t       dctn = 0;
+
+    if (dm) {
+        dm->task->alltoall.blocks_sent++;
+    }
+    if (a2a->is_dc) {
+        ah   = a2a->net.ahs[rank];
+        dctn = a2a->net.remote_dctns[rank];
+    }
+    return ucc_tl_mlx5_post_rdma(qp, dctn, ah, src_addr, msg_size, lkey,
+                                 remote_addr, rkey, send_flags, (uintptr_t)dm);
+}
+
+static inline void send_start(ucc_tl_mlx5_team_t *team, ucc_rank_t rank)
+{
+    ibv_wr_start(tl_mlx5_get_qp_ex(team->a2a, rank));
+}
+
+static inline ucc_status_t send_done(ucc_tl_mlx5_team_t *team, ucc_rank_t rank)
+{
+    if (ibv_wr_complete(tl_mlx5_get_qp_ex(team->a2a, rank))) {
+        tl_error(UCC_TL_TEAM_LIB(team), "ibv_wr_complete failed, errno %d",
+                 errno);
+        return UCC_ERR_NO_MESSAGE;
+    }
+    return UCC_OK;
+}
+
+static inline ucc_status_t send_atomic(ucc_tl_mlx5_alltoall_t *a2a,
+                                       ucc_rank_t rank, void *remote_addr,
+                                       uint32_t rkey)
+{
+    struct ibv_qp_ex    *qp_ex;
+    struct mlx5dv_qp_ex *qp_dv;
+
+    qp_ex           = tl_mlx5_get_qp_ex(a2a, rank);
+    qp_ex->wr_flags = 0;
+    ibv_wr_atomic_fetch_add(qp_ex, rkey, (uintptr_t)remote_addr, 1ULL);
+    if (a2a->is_dc) {
+        qp_dv = mlx5dv_qp_ex_from_ibv_qp_ex(qp_ex);
+        mlx5dv_wr_set_dc_addr(qp_dv, a2a->net.ahs[rank],
+                              a2a->net.remote_dctns[rank], DC_KEY);
+    }
+    ibv_wr_set_sge(qp_ex, a2a->atomic_scratch_bf_mr->lkey,
+                   (uint64_t)a2a->atomic_scratch_bf_mr->addr,
+                   a2a->atomic_scratch_bf_mr->length);
+    return UCC_OK;
+}
+
+static inline void *tl_mlx5_atomic_addr(ucc_tl_mlx5_schedule_t *task,
+                                        ucc_rank_t              rank)
+{
+    void *remote_atomic = NULL;
+#if !ATOMIC_IN_MEMIC
+    ucc_tl_mlx5_team_t *team = SCHEDULE_TEAM(task);
+
+    remote_atomic = team->a2a->net.remote_ctrl[rank].atomic.addr;
+#endif
+    return PTR_OFFSET(remote_atomic,
+                      task->alltoall.seq_index * sizeof(tl_mlx5_atomic_t));
+}
+
+static inline uint32_t tl_mlx5_atomic_rkey(ucc_tl_mlx5_schedule_t *task,
+                                           ucc_rank_t              rank)
+{
+    ucc_tl_mlx5_team_t *team = SCHEDULE_TEAM(task);
+
+    return team->a2a->net.remote_ctrl[rank].atomic.rkey;
+}
+
+static inline tl_mlx5_barrier_t
+tl_mlx5_barrier_flag(ucc_tl_mlx5_schedule_t *task, ucc_rank_t rank)
+{
+    ucc_tl_mlx5_team_t *team     = SCHEDULE_TEAM(task);
+    ucc_rank_t          net_size = team->a2a->net.net_size;
+
+    return team->a2a->net.barrier
+        .flags[(net_size + 1) * task->alltoall.seq_index + rank];
+}
+
+static inline void tl_mlx5_barrier_flag_set(ucc_tl_mlx5_schedule_t *task,
+                                            ucc_rank_t              rank)
+{
+    ucc_tl_mlx5_team_t *team     = SCHEDULE_TEAM(task);
+    ucc_rank_t          net_size = team->a2a->net.net_size;
+
+    team->a2a->net.barrier
+        .flags[(net_size + 1) * task->alltoall.seq_index + rank] =
+        task->alltoall.seq_num;
+}
+
+static inline tl_mlx5_barrier_t *
+tl_mlx5_barrier_local_addr(ucc_tl_mlx5_schedule_t *task)
+{
+    ucc_tl_mlx5_team_t *team     = SCHEDULE_TEAM(task);
+    ucc_rank_t          net_size = team->a2a->net.net_size;
+
+    return &team->a2a->net.barrier
+                .flags[(net_size + 1) * task->alltoall.seq_index + net_size];
+}
+
+static inline uintptr_t
+tl_mlx5_barrier_my_remote_addr(ucc_tl_mlx5_schedule_t *task, ucc_rank_t rank)
+{
+    ucc_tl_mlx5_team_t *team     = SCHEDULE_TEAM(task);
+    ucc_rank_t          net_size = team->a2a->net.net_size;
+    ucc_rank_t          net_rank = team->a2a->net.sbgp->group_rank;
+    void *              remote_barrier;
+    ptrdiff_t           offset;
+
+    remote_barrier = team->a2a->net.remote_ctrl[rank].barrier.addr;
+    offset         = (task->alltoall.seq_index * (net_size + 1) + net_rank) *
+                                        sizeof(tl_mlx5_barrier_t);
+    return (uintptr_t)PTR_OFFSET(remote_barrier, offset);
+}
+
+static inline uint32_t tl_mlx5_barrier_remote_rkey(ucc_tl_mlx5_schedule_t *task,
+                                                   ucc_rank_t              rank)
+{
+    ucc_tl_mlx5_team_t *team = SCHEDULE_TEAM(task);
+
+    return team->a2a->net.remote_ctrl[rank].barrier.rkey;
+}
+
+#endif

--- a/src/components/tl/mlx5/configure.m4
+++ b/src/components/tl/mlx5/configure.m4
@@ -6,8 +6,11 @@ tl_mlx5_enabled=n
 CHECK_TLS_REQUIRED(["mlx5"])
 AS_IF([test "$CHECKED_TL_REQUIRED" = "y"],
 [
+    CHECK_RDMACM
+    AC_MSG_RESULT([RDMACM support: $rdmacm_happy])
+
     mlx5_happy=no
-    if test "x$mlx5dv_happy" = "xyes" -a "x$have_mlx5dv_wr_raw_wqe" = "xyes"; then
+    if test "x$mlx5dv_happy" = "xyes" -a "x$have_mlx5dv_wr_raw_wqe" = "xyes" -a "x$rdmacm_happy" = "xyes"; then
        mlx5_happy=yes
     fi
     AC_MSG_RESULT([MLX5 support: $mlx5_happy])

--- a/src/components/tl/mlx5/mcast/p2p/ucc_tl_mlx5_mcast_p2p.c
+++ b/src/components/tl/mlx5/mcast/p2p/ucc_tl_mlx5_mcast_p2p.c
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "ucc_tl_mlx5_mcast_p2p.h"
+
+static inline void ucc_tl_mlx5_mcast_p2p_completion_cb(void* context)
+{
+    ucc_tl_mlx5_mcast_p2p_completion_obj_t *obj =
+        (ucc_tl_mlx5_mcast_p2p_completion_obj_t *)context;
+
+    ucc_assert(obj != NULL && obj->compl_cb != NULL);
+
+    obj->compl_cb(obj);
+
+    ucc_assert(obj->req != NULL);
+
+    ucc_collective_finalize(obj->req);
+}
+
+void ucc_tl_mlx5_mcast_completion_cb(void* context, ucc_status_t status) //NOLINT
+{
+    ucc_tl_mlx5_mcast_p2p_completion_cb(context);
+}
+
+static inline ucc_status_t ucc_tl_mlx5_mcast_do_p2p_bcast_nb(void *buf, size_t
+                                                             len, ucc_rank_t my_team_rank, ucc_rank_t dest,
+                                                             ucc_team_h team, ucc_context_h ctx,
+                                                             ucc_coll_callback_t *callback,
+                                                             ucc_coll_req_h *p2p_req, int is_send)
+{
+    ucc_status_t    status = UCC_OK;
+    ucc_coll_req_h  req    = NULL;
+    ucc_coll_args_t args;
+
+    args.mask              = UCC_COLL_ARGS_FIELD_ACTIVE_SET |
+                             UCC_COLL_ARGS_FIELD_CB;
+    args.coll_type         = UCC_COLL_TYPE_BCAST;
+    args.src.info.buffer   = buf;
+    args.src.info.count    = len;
+    args.src.info.datatype = UCC_DT_INT8;
+    args.src.info.mem_type = UCC_MEMORY_TYPE_HOST;
+    args.root              = is_send ? my_team_rank : dest;
+    args.cb.cb             = callback->cb;
+    args.cb.data           = callback->data;
+    args.active_set.size   = 2;
+    args.active_set.start  = my_team_rank;
+    args.active_set.stride = dest - my_team_rank;
+
+    status = ucc_collective_init(&args, &req, team);
+    if (ucc_unlikely(UCC_OK != status)) {
+        tl_error(ctx->lib, "nonblocking p2p init failed");
+        return status;
+    }
+
+    ((ucc_tl_mlx5_mcast_p2p_completion_obj_t *)args.cb.data)->req = req;
+
+    status = ucc_collective_post(req);
+    if (ucc_unlikely(UCC_OK != status)) {
+        tl_error(ctx->lib, "nonblocking p2p post failed");
+        return status;
+    }
+
+    *p2p_req = req;
+
+    return status;
+}
+
+static inline ucc_status_t do_send_nb(void *sbuf, size_t len, ucc_rank_t
+                                      my_team_rank, ucc_rank_t dest, ucc_team_h team,
+                                      ucc_context_h ctx, ucc_coll_callback_t
+                                      *callback, ucc_coll_req_h *req)
+{
+    return ucc_tl_mlx5_mcast_do_p2p_bcast_nb(sbuf, len, my_team_rank, dest,
+                                             team, ctx, callback, req, 1);
+}
+
+static inline ucc_status_t do_recv_nb(void *rbuf, size_t len, ucc_rank_t
+                                      my_team_rank, ucc_rank_t dest, ucc_team_h team,
+                                      ucc_context_h ctx, ucc_coll_callback_t
+                                      *callback, ucc_coll_req_h *req)
+{
+    return ucc_tl_mlx5_mcast_do_p2p_bcast_nb(rbuf, len, my_team_rank, dest,
+                                             team, ctx, callback, req, 0);
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_p2p_send_nb(void* src, size_t size, ucc_rank_t
+                                           rank, void *context,
+                                           ucc_tl_mlx5_mcast_p2p_completion_obj_t
+                                           *obj)
+{
+    ucc_tl_mlx5_mcast_oob_p2p_context_t *oob_p2p_ctx  =
+                                   (ucc_tl_mlx5_mcast_oob_p2p_context_t *)context;
+    ucc_status_t                         status       = UCC_OK;
+    ucc_coll_req_h                       req          = NULL;
+    ucc_rank_t                           my_team_rank = oob_p2p_ctx->my_team_rank;
+    ucc_team_h                           team         = oob_p2p_ctx->base_team;
+    ucc_context_h                        ctx          = oob_p2p_ctx->base_ctx;
+    ucc_coll_callback_t                  callback;
+
+    callback.cb   = ucc_tl_mlx5_mcast_completion_cb;
+    callback.data = obj;
+
+    status = do_send_nb(src, size, my_team_rank, rank, team, ctx, &callback, &req);
+
+    if (status < 0) {
+        tl_error(ctx->lib, "nonblocking p2p send failed");
+        return status;
+    }
+
+    return status;
+}
+
+ucc_status_t ucc_tl_mlx5_mcast_p2p_recv_nb(void *dst, size_t size, ucc_rank_t
+                                           rank, void *context,
+                                           ucc_tl_mlx5_mcast_p2p_completion_obj_t
+                                           *obj)
+{
+    ucc_tl_mlx5_mcast_oob_p2p_context_t *oob_p2p_ctx  =
+                                   (ucc_tl_mlx5_mcast_oob_p2p_context_t *)context;
+    ucc_status_t                         status       = UCC_OK;
+    ucc_coll_req_h                       req          = NULL;
+    ucc_rank_t                           my_team_rank = oob_p2p_ctx->my_team_rank;
+    ucc_team_h                           team         = oob_p2p_ctx->base_team;
+    ucc_context_h                        ctx          = oob_p2p_ctx->base_ctx;
+    ucc_coll_callback_t                  callback;
+
+    callback.cb   = ucc_tl_mlx5_mcast_completion_cb;
+    callback.data = obj;
+
+    status = do_recv_nb(dst, size, my_team_rank, rank, team, ctx, &callback, &req);
+
+    if (status < 0) {
+        tl_error(ctx->lib, "nonblocking p2p recv failed");
+        return status;
+    }
+
+    return status;
+}

--- a/src/components/tl/mlx5/mcast/p2p/ucc_tl_mlx5_mcast_p2p.h
+++ b/src/components/tl/mlx5/mcast/p2p/ucc_tl_mlx5_mcast_p2p.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include <ucc/api/ucc.h>
+#include "components/tl/mlx5/mcast/tl_mlx5_mcast.h"
+
+ucc_status_t ucc_tl_mlx5_mcast_p2p_send_nb(void* src, size_t size, ucc_rank_t
+                                           rank, void *context,
+                                           ucc_tl_mlx5_mcast_p2p_completion_obj_t
+                                           *obj);
+
+ucc_status_t ucc_tl_mlx5_mcast_p2p_recv_nb(void* dst, size_t size, ucc_rank_t
+                                           rank, void *context,
+                                           ucc_tl_mlx5_mcast_p2p_completion_obj_t
+                                           *obj);

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast.h
@@ -20,8 +20,38 @@
 
 #define UCC_TL_MLX5_MCAST_ENABLE_BLOCKING true
 
+struct ucc_tl_mlx5_mcast_p2p_completion_obj;
+typedef int (*ucc_tl_mlx5_mcast_p2p_completion_cb_fn_t)(struct ucc_tl_mlx5_mcast_p2p_completion_obj *obj);
+typedef struct ucc_tl_mlx5_mcast_p2p_completion_obj {
+    ucc_list_link_t                          super;
+    ucc_tl_mlx5_mcast_p2p_completion_cb_fn_t compl_cb;
+    uint64_t                                 data[3];
+    ucc_coll_req_h                           req;
+} ucc_tl_mlx5_mcast_p2p_completion_obj_t;
+
 typedef struct mcast_coll_comm_init_spec {
 } mcast_coll_comm_init_spec_t;
+
+typedef int (*ucc_tl_mlx5_mcast_p2p_wait_cb_fn_t)(void *wait_arg);
+
+typedef int (*ucc_tl_mlx5_mcast_p2p_send_nb_fn_t)(void* src, size_t size,
+                                                  ucc_rank_t rank, void *context,
+                                                  ucc_tl_mlx5_mcast_p2p_completion_obj_t *compl_obj);
+
+
+typedef int (*ucc_tl_mlx5_mcast_p2p_recv_nb_fn_t)(void* src, size_t size,
+                                                  ucc_rank_t rank, void *context,
+                                                  ucc_tl_mlx5_mcast_p2p_completion_obj_t *compl_obj);
+
+typedef struct ucc_tl_mlx5_mcast_context_config {
+    ucc_tl_context_config_t  super;
+    char                    *dev_list;
+    int                      use_rcache;
+    size_t                   reg_threshold;
+    unsigned int             rand_seed;
+    unsigned int             uprogress_num_polls;
+    int                      context_per_team;
+} ucc_tl_mlx5_mcast_context_config_t;
 
 typedef struct ucc_tl_mlx5_mcast_lib {
 } ucc_tl_mlx5_mcast_lib_t;
@@ -31,11 +61,48 @@ UCC_CLASS_DECLARE(ucc_tl_mlx5_mcast_lib_t, const ucc_base_lib_params_t *,
 typedef struct ucc_tl_mlx5_mcast_ctx_params {
 } ucc_tl_mlx5_mcast_ctx_params_t;
 
-typedef struct mcast_coll_context_t {
-} mcast_coll_context_t;
+typedef struct ucc_tl_mlx5_mcast_coll_context {
+    struct ibv_context            *ctx;
+    struct ibv_pd                 *pd;
+    char                          *devname;
+    int                            max_qp_wr;
+    int                            ib_port;
+    int                            pkey_index;
+    int                            mtu;
+    struct rdma_cm_id             *id;
+    struct rdma_event_channel     *channel;
+    ucc_mpool_t                    compl_objects_mp;
+    ucc_mpool_t                    nack_reqs_mp;
+    ucc_list_link_t                pending_nacks_list;
+    ucc_rcache_t                  *rcache;
+    ucc_tl_mlx5_mcast_ctx_params_t params;
+    ucc_base_lib_t                *lib;
+} ucc_tl_mlx5_mcast_coll_context_t;
 
-typedef struct ucc_tl_mlx5_mcast_context_t {
+typedef struct ucc_tl_mlx5_mcast_oob_ctx {
+    void               *ctx;
+    union {
+        ucc_oob_coll_t *oob;
+        ucc_subset_t    subset;
+    };
+} ucc_tl_mlx5_mcast_oob_ctx_t;
+
+typedef struct ucc_tl_mlx5_mcast_context {
+    ucc_thread_mode_t                  tm;
+    ucc_tl_mlx5_mcast_coll_context_t   mcast_context;
+    ucc_tl_mlx5_mcast_context_config_t cfg;
+    ucc_mpool_t                        req_mp;
+    ucc_tl_mlx5_mcast_oob_ctx_t        oob_ctx;
 } ucc_tl_mlx5_mcast_context_t;
+
+typedef struct ucc_tl_mlx5_mcast_reg {
+    void *mr;
+} ucc_tl_mlx5_mcast_reg_t;
+
+typedef struct ucc_tl_mlx5_mcast_rcache_region {
+    ucc_rcache_region_t     super;
+    ucc_tl_mlx5_mcast_reg_t reg;
+} ucc_tl_mlx5_mcast_rcache_region_t;
 
 
 typedef struct mcast_coll_comm { /* Stuff at a per-communicator sort of level */
@@ -47,6 +114,13 @@ typedef struct ucc_tl_mlx5_mcast_team {
 
 typedef struct ucc_tl_mlx5_mcast_coll_req { /* Stuff that has to happen per call */
 } ucc_tl_mlx5_mcast_coll_req_t;
+
+typedef struct ucc_tl_mlx5_mcast_oob_p2p_context {
+    ucc_context_h base_ctx;
+    ucc_team_h    base_team;
+    ucc_rank_t    my_team_rank;
+    ucc_subset_t  subset;
+} ucc_tl_mlx5_mcast_oob_p2p_context_t;
 
 #define TASK_TEAM_MCAST(_task)                                                       \
     (ucc_derived_of((_task)->super.team, ucc_tl_mlx5_mcast_team_t))

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_coll.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_coll.c
@@ -37,7 +37,7 @@ ucc_status_t ucc_tl_mlx5_mcast_bcast_start(ucc_coll_task_t *coll_task)
 
     status = mcast_coll_do_bcast(buf, data_size, root, NULL, comm,
                             UCC_TL_MLX5_MCAST_ENABLE_BLOCKING, &task->bcast_mcast.req_handle);
-    if (UCC_OK != status && UCC_INPROGRESS != status) {
+    if (status < 0) {
         tl_error(UCC_TASK_LIB(task), "mcast_coll_do_bcast failed:%d", status);
         coll_task->status = status;
         return ucc_task_complete(coll_task);

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_rcache.c
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_rcache.c
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_mlx5_mcast_rcache.h"
+
+static ucs_status_t ucc_tl_mlx5_mcast_coll_reg_mr(ucc_tl_mlx5_mcast_coll_context_t
+                                                 *ctx, void *data, size_t data_size,
+                                                  void **mr)
+{
+    *mr = ibv_reg_mr(ctx->pd, data, data_size, IBV_ACCESS_LOCAL_WRITE |
+                     IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE);
+
+    tl_trace(ctx->lib, "external memory register: ptr %p, len %zd, mr %p",
+             data,  data_size, (*mr));
+    if (!*mr) {
+        tl_error(ctx->lib, "failed to register MR");
+        return UCS_ERR_NO_MEMORY;
+    }
+    
+    return UCS_OK;
+}
+
+
+static ucc_status_t ucc_tl_mlx5_mcast_coll_dereg_mr(ucc_tl_mlx5_mcast_coll_context_t
+                                                   *ctx, void *mr)
+{
+    if (ucc_unlikely(NULL == mr)) {
+        tl_debug(ctx->lib, "external memory mr %p already deregistered", mr);
+        return UCC_OK;
+    }
+
+    tl_debug(ctx->lib, "external memory deregister: mr %p", mr);
+    
+    if (ibv_dereg_mr(mr)) {
+        tl_error(ctx->lib, "couldn't destroy mr %p", mr);
+        return UCC_ERR_NO_RESOURCE;
+    }
+
+    return UCC_OK;
+}
+
+static ucs_status_t
+ucc_tl_mlx5_mcast_rcache_mem_reg_cb(void *context, ucs_rcache_t *rcache, //NOLINT
+                                    void *arg, ucs_rcache_region_t *rregion, //NOLINT
+                                    uint16_t flags) //NOLINT
+{
+    ucc_tl_mlx5_mcast_rcache_region_t *region;
+    void                              *address;
+    size_t                             length;
+
+    address = (void*)rregion->super.start;
+    length  = (size_t)(rregion->super.end - rregion->super.start);
+    region  = ucc_derived_of(rregion, ucc_tl_mlx5_mcast_rcache_region_t);
+
+    return ucc_tl_mlx5_mcast_coll_reg_mr((ucc_tl_mlx5_mcast_coll_context_t *)context,
+                                         address, length, &region->reg.mr);
+}
+
+static void ucc_tl_mlx5_mcast_rcache_mem_dereg_cb(void *context, ucc_rcache_t   //NOLINT
+                                                 *rcache, ucc_rcache_region_t *rregion) //NOLINT
+{
+    ucc_tl_mlx5_mcast_rcache_region_t *region = ucc_derived_of(rregion,
+                                                ucc_tl_mlx5_mcast_rcache_region_t);
+
+    ucc_tl_mlx5_mcast_coll_dereg_mr((ucc_tl_mlx5_mcast_coll_context_t *)context,
+                                     region->reg.mr);
+}
+
+static void ucc_tl_mlx5_mcast_rcache_dump_region_cb(void *context,  //NOLINT
+                                                    ucc_rcache_t *rcache,   //NOLINT
+                                                    ucc_rcache_region_t *rregion,   //NOLINT
+                                                    char *buf,  //NOLINT
+                                                    size_t max) //NOLINT
+{
+    ucc_tl_mlx5_mcast_rcache_region_t *region = ucc_derived_of(rregion,
+                                           ucc_tl_mlx5_mcast_rcache_region_t);
+
+    snprintf(buf, max, "bar ptr:%p", region->reg.mr);
+}
+
+ucc_status_t
+ucc_tl_mlx5_mcast_mem_register(ucc_tl_mlx5_mcast_coll_context_t *ctx,
+                               void *addr, size_t length,
+                               ucc_tl_mlx5_mcast_reg_t **reg)
+{
+    ucc_rcache_region_t               *rregion;
+    ucc_tl_mlx5_mcast_rcache_region_t *region;
+    ucc_status_t                       status;
+    ucc_rcache_t                      *rcache;
+
+    rcache = ctx->rcache;
+
+    ucc_assert(rcache != NULL);
+
+    status = ucc_rcache_get(rcache, (void *)addr, length, NULL, &rregion);
+    if (ucc_unlikely(UCC_OK != status)) {
+        tl_error(ctx->lib, "ucc_rcache_get failed");
+        return status;
+    }
+
+    region = ucc_derived_of(rregion, ucc_tl_mlx5_mcast_rcache_region_t);
+    *reg   = &region->reg;
+
+    tl_trace(ctx->lib, "memory register mr %p", (*reg)->mr);
+
+    return UCC_OK;
+}
+
+ucc_status_t
+ucc_tl_mlx5_mcast_mem_deregister(ucc_tl_mlx5_mcast_coll_context_t *ctx,
+                                 ucc_tl_mlx5_mcast_reg_t *reg)
+{
+    ucc_tl_mlx5_mcast_rcache_region_t *region;
+    ucc_rcache_t                      *rcache;
+
+    rcache = ctx->rcache;
+
+    if (reg == NULL) {
+        return UCC_OK;
+    }
+
+    ucc_assert(rcache != NULL);
+    tl_trace(ctx->lib, "memory deregister mr %p", reg->mr);
+    region = ucc_container_of(reg, ucc_tl_mlx5_mcast_rcache_region_t, reg);
+    ucc_rcache_region_put(rcache, &region->super);
+
+    return UCC_OK;
+}
+
+static ucc_rcache_ops_t ucc_rcache_ops = {
+    .mem_reg     = ucc_tl_mlx5_mcast_rcache_mem_reg_cb,
+    .mem_dereg   = ucc_tl_mlx5_mcast_rcache_mem_dereg_cb,
+    .dump_region = ucc_tl_mlx5_mcast_rcache_dump_region_cb
+};
+
+ucc_status_t ucc_tl_mlx5_mcast_setup_rcache(ucc_tl_mlx5_mcast_coll_context_t *ctx)
+{
+    ucc_rcache_params_t rcache_params;
+
+    rcache_params.alignment          = 64;
+    rcache_params.ucm_event_priority = 1000;
+    rcache_params.max_regions        = ULONG_MAX;
+    rcache_params.max_size           = SIZE_MAX;
+    rcache_params.region_struct_size = sizeof(ucc_tl_mlx5_mcast_rcache_region_t);
+    rcache_params.max_alignment      = ucc_get_page_size();
+    rcache_params.ucm_events         = UCM_EVENT_VM_UNMAPPED |
+                                       UCM_EVENT_MEM_TYPE_FREE;
+    rcache_params.context            = ctx;
+    rcache_params.ops                = &ucc_rcache_ops;
+    rcache_params.flags              = 0;
+
+    return ucc_rcache_create(&rcache_params, "MCAST", &ctx->rcache);
+}

--- a/src/components/tl/mlx5/mcast/tl_mlx5_mcast_rcache.h
+++ b/src/components/tl/mlx5/mcast/tl_mlx5_mcast_rcache.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+
+#include "tl_mlx5_mcast.h"
+#include "utils/ucc_rcache.h"
+
+ucc_status_t ucc_tl_mlx5_mcast_setup_rcache(ucc_tl_mlx5_mcast_coll_context_t *ctx);
+
+ucc_status_t ucc_tl_mlx5_mcast_mem_register(ucc_tl_mlx5_mcast_coll_context_t
+                                           *ctx, void *addr, size_t length,
+                                            ucc_tl_mlx5_mcast_reg_t **reg);
+
+ucc_status_t ucc_tl_mlx5_mcast_mem_deregister(ucc_tl_mlx5_mcast_coll_context_t *ctx,
+                                              ucc_tl_mlx5_mcast_reg_t *reg);

--- a/src/components/tl/mlx5/tl_mlx5.h
+++ b/src/components/tl/mlx5/tl_mlx5.h
@@ -84,6 +84,7 @@ typedef struct ucc_tl_mlx5_context {
     ucc_rcache_t                *rcache;
     int                          is_imported;
     int                          ib_port;
+    int                          sock;
     ucc_mpool_t                  req_mp;
     ucc_tl_mlx5_mcast_context_t  mcast;
 } ucc_tl_mlx5_context_t;
@@ -108,15 +109,20 @@ typedef enum
     TL_MLX5_TEAM_STATE_ALLTOALL_POSTED
 } ucc_tl_mlx5_team_state_t;
 
+typedef struct ucc_tl_mlx5_team_status {
+    ucc_status_t local;
+    ucc_status_t global;
+} ucc_tl_mlx5_team_status_t;
+
 typedef struct ucc_tl_mlx5_team {
     ucc_tl_team_t             super;
-    ucc_status_t              status[2];
     ucc_service_coll_req_t   *scoll_req;
     ucc_tl_mlx5_team_state_t  state;
     void                     *dm_offset;
     ucc_mpool_t               dm_pool;
     struct ibv_dm            *dm_ptr;
     struct ibv_mr            *dm_mr;
+    ucc_tl_mlx5_team_status_t a2a_status;
     ucc_tl_mlx5_alltoall_t   *a2a;
     ucc_topo_t               *topo;
     ucc_ep_map_t              ctx_map;

--- a/src/components/tl/mlx5/tl_mlx5_coll.c
+++ b/src/components/tl/mlx5/tl_mlx5_coll.c
@@ -31,7 +31,7 @@ ucc_status_t ucc_tl_mlx5_bcast_mcast_init(ucc_base_coll_args_t *coll_args,
     if (ucc_unlikely(UCC_OK != status)) {
         goto free_task;
     }
-       
+
     *task_h = &(task->super);
 
     tl_debug(UCC_TASK_LIB(task), "init coll task %p", task);

--- a/src/components/tl/mlx5/tl_mlx5_coll.h
+++ b/src/components/tl/mlx5/tl_mlx5_coll.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -57,7 +57,20 @@ typedef struct ucc_tl_mlx5_schedule {
 #define TASK_SCHEDULE(_task)                                                   \
     (ucc_derived_of((_task)->schedule, ucc_tl_mlx5_schedule_t))
 
-static inline ucc_tl_mlx5_task_t *
+#define SCHEDULE_TEAM(_schedule)                                               \
+    (ucc_derived_of((_schedule)->super.super.team, ucc_tl_mlx5_team_t))
+
+#define SCHEDULE_CTX(_schedule)                                                \
+    (ucc_derived_of((_schedule)->super.super.team->context,                    \
+                    ucc_tl_mlx5_context_t))
+
+#define SCHEDULE_LIB(_schedule)                                                \
+    (ucc_derived_of((_schedule)->super.super.team->context->lib,               \
+                    ucc_tl_mlx5_lib_t))
+
+#define SCHEDULE_ARGS(_schedule) (_schedule)->super.super.bargs.args
+
+static inline ucc_tl_mlx5_task_t*
 ucc_tl_mlx5_get_task(ucc_base_coll_args_t *coll_args, ucc_base_team_t *team)
 {
     ucc_tl_mlx5_team_t *   tl_team = ucc_derived_of(team, ucc_tl_mlx5_team_t);
@@ -80,7 +93,7 @@ ucc_tl_mlx5_get_schedule(ucc_tl_mlx5_team_t      *team,
                          ucc_base_coll_args_t    *coll_args,
                          ucc_tl_mlx5_schedule_t **schedule)
 {
-    ucc_tl_mlx5_context_t * ctx      = UCC_TL_MLX5_TEAM_CTX(team);
+    ucc_tl_mlx5_context_t *ctx = UCC_TL_MLX5_TEAM_CTX(team);
 
     *schedule = ucc_mpool_get(&ctx->req_mp);
 
@@ -100,7 +113,17 @@ static inline void ucc_tl_mlx5_put_schedule(ucc_tl_mlx5_schedule_t *schedule)
 }
 
 ucc_status_t ucc_tl_mlx5_bcast_mcast_init(ucc_base_coll_args_t *coll_args,
-                                          ucc_base_team_t *     team,
-                                          ucc_coll_task_t **    task_h);
+                                          ucc_base_team_t      *team,
+                                          ucc_coll_task_t     **task_h);
+
+ucc_status_t ucc_tl_mlx5_task_finalize(ucc_coll_task_t *coll_task);
+
+ucc_tl_mlx5_task_t* ucc_tl_mlx5_init_task(ucc_base_coll_args_t *coll_args,
+                                          ucc_base_team_t      *team,
+                                          ucc_schedule_t       *schedule);
+
+ucc_status_t ucc_tl_mlx5_coll_init(ucc_base_coll_args_t *coll_args,
+                                   ucc_base_team_t      *team,
+                                   ucc_coll_task_t     **task_h);
 
 #endif

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -203,7 +203,7 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
                 goto err;
             }
 
-            strncat(sock_path, sockname, strlen(sockname));
+            strncat(sock_path, sockname, sizeof(sock_path) - strlen(sock_path) - 1);
             status = ucc_tl_mlx5_socket_init(ctx, sbgp->group_size, &sock,
                                              sock_path);
             if (UCC_OK != status) {

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -92,7 +92,7 @@ ucc_status_t ucc_tl_mlx5_ib_ctx_pd_init(ucc_tl_mlx5_context_t *ctx)
         pos         = strstr(ib_devname, ":");
         end_pos     = ib_devname + strlen(ib_devname);
         if (!pos) {
-            devname_len = strlen(ib_devname);
+            devname_len = sizeof(tmp) - 1;
         } else {
             devname_len = (int)(pos - ib_devname);
             pos++;
@@ -161,6 +161,12 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
     ucc_coll_task_t *req;
     ucc_tl_mlx5_context_create_sbcast_data_t *sbcast_data;
 
+    if (!core_ctx->service_team) {
+        tl_debug(context->lib, "failed to init ctx: need service team");
+        return UCC_ERR_NO_MESSAGE;
+    }
+    ucc_assert(core_ctx->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB);
+
     sbcast_data = (ucc_tl_mlx5_context_create_sbcast_data_t *)ucc_malloc(
         sbcast_data_length);
     if (!sbcast_data) {
@@ -168,9 +174,6 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
                  "failed to allocate buffer for sharing ib_ctx info");
         return UCC_ERR_NO_MEMORY;
     }
-
-    ucc_assert(core_ctx->service_team != NULL);
-    ucc_assert(core_ctx->params.mask & UCC_CONTEXT_PARAM_FIELD_OOB);
 
     s.map.type   = UCC_EP_MAP_FULL;
     s.map.ep_num = core_ctx->params.oob.n_oob_eps;

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -175,6 +175,7 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
         return UCC_ERR_NO_MEMORY;
     }
 
+    memset(&s.map, 0, sizeof(ucc_ep_map_t));
     s.map.type   = UCC_EP_MAP_FULL;
     s.map.ep_num = core_ctx->params.oob.n_oob_eps;
     s.myrank     = core_ctx->rank;
@@ -266,12 +267,13 @@ ucc_status_t ucc_tl_mlx5_context_create_epilog(ucc_base_context_t *context)
 
     ucc_free(sbcast_data);
     ucc_topo_cleanup(topo);
-
+    close(sock);
     return UCC_OK;
 
 err:
     ucc_tl_mlx5_remove_shared_ctx_pd(ctx);
     ucc_topo_cleanup(topo);
+    close(sock);
 err_topo:
     ucc_free(sbcast_data);
     return status;

--- a/src/components/tl/mlx5/tl_mlx5_context.c
+++ b/src/components/tl/mlx5/tl_mlx5_context.c
@@ -26,6 +26,7 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_context_t,
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_context_t, &tl_mlx5_config->super,
                               params->context);
     memcpy(&self->cfg, tl_mlx5_config, sizeof(*tl_mlx5_config));
+    self->sock       = 0;
     self->rcache     = NULL;
     self->shared_pd  = NULL;
     self->shared_ctx = NULL;
@@ -73,8 +74,11 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_context_t)
         tl_debug(self->super.super.lib, "failed to free ib ctx and pd");
     };
 
+    if (!self->sock) {
+        close(self->sock);
+    }
+
     ucc_mpool_cleanup(&self->req_mp, 1);
-    close(self->sock);
 }
 
 UCC_CLASS_DEFINE(ucc_tl_mlx5_context_t, ucc_tl_context_t);

--- a/src/components/tl/mlx5/tl_mlx5_dm.c
+++ b/src/components/tl/mlx5/tl_mlx5_dm.c
@@ -5,8 +5,71 @@
  */
 
 #include "tl_mlx5_dm.h"
+#include "alltoall/alltoall.h"
 
 #define DM_HOST_AUTO_NUM_CHUNKS 8
+
+static void ucc_tl_mlx5_alltoall_atomic_free(ucc_tl_mlx5_team_t *team)
+{
+    if (!team->a2a || !team->a2a->net.atomic.counters) {
+        return;
+    }
+
+    ibv_dereg_mr(team->a2a->net.atomic.mr);
+#if ATOMIC_IN_MEMIC
+    ibv_free_dm(team->a2a->net.atomic.counters);
+#else
+    ucc_free(team->a2a->net.atomic.counters);
+#endif
+    team->a2a->net.atomic.counters = NULL;
+}
+
+static ucc_status_t ucc_tl_mlx5_alltoall_atomic_alloc(ucc_tl_mlx5_team_t *team)
+{
+    ucc_tl_mlx5_context_t  *ctx = UCC_TL_MLX5_TEAM_CTX(team);
+    ucc_tl_mlx5_alltoall_t *a2a = team->a2a;
+    size_t                  size;
+
+    size = sizeof(*a2a->net.atomic.counters) * MAX_OUTSTANDING_OPS;
+#if ATOMIC_IN_MEMIC
+    struct ibv_alloc_dm_attr dm_attr;
+    memset(&dm_attr, 0, sizeof(dm_attr));
+    dm_attr.length           = size;
+    a2a->net.atomic.counters = ibv_alloc_dm(ctx->shared_ctx, &dm_attr);
+#else
+    a2a->net.atomic.counters = ucc_malloc(size, "atomic");
+#endif
+
+    if (!a2a->net.atomic.counters) {
+        tl_debug(UCC_TL_TEAM_LIB(team),
+                 "failed to allocate %zd bytes for atomic counters array",
+                 size);
+        return UCC_ERR_NO_MEMORY;
+    }
+#if ATOMIC_IN_MEMIC
+    a2a->net.atomic.mr =
+        ibv_reg_dm_mr(ctx->shared_pd, a2a->net.atomic.counters, 0, size,
+                      IBV_ACCESS_REMOTE_ATOMIC | IBV_ACCESS_LOCAL_WRITE |
+                          IBV_ACCESS_ZERO_BASED);
+
+#else
+    a2a->net.atomic.mr =
+        ibv_reg_mr(ctx->shared_pd, a2a->net.atomic.counters, size,
+                   IBV_ACCESS_REMOTE_ATOMIC | IBV_ACCESS_LOCAL_WRITE);
+#endif
+
+    if (!a2a->net.atomic.mr) {
+        tl_error(UCC_TL_TEAM_LIB(team),
+                 "failed to register atomic couters array");
+#if ATOMIC_IN_MEMIC
+        ibv_free_dm(a2a->net.atomic.counters);
+#else
+        ucc_free(a2a->net.atomic.counters);
+#endif
+        return UCC_ERR_NO_MESSAGE;
+    }
+    return UCC_OK;
+}
 
 static void ucc_tl_mlx5_dm_chunk_init(ucc_mpool_t *mp,        //NOLINT
                                       void *obj, void *chunk) //NOLINT
@@ -26,7 +89,7 @@ static ucc_mpool_ops_t ucc_tl_mlx5_dm_ops = {
     .obj_init      = ucc_tl_mlx5_dm_chunk_init,
     .obj_cleanup   = NULL};
 
-void ucc_tl_mlx5_dm_cleanup(ucc_tl_mlx5_team_t *team)
+void ucc_tl_mlx5_dm_pool_cleanup(ucc_tl_mlx5_team_t *team)
 {
     if (!team->dm_ptr) {
         return;
@@ -40,6 +103,13 @@ void ucc_tl_mlx5_dm_cleanup(ucc_tl_mlx5_team_t *team)
     } else {
         ibv_free_dm(team->dm_ptr);
     }
+    team->dm_ptr = NULL;
+}
+
+void ucc_tl_mlx5_dm_cleanup(ucc_tl_mlx5_team_t *team)
+{
+    ucc_tl_mlx5_dm_pool_cleanup(team);
+    ucc_tl_mlx5_alltoall_atomic_free(team);
 }
 
 ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
@@ -61,14 +131,14 @@ ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
         dm_attr.length      = max_chunks_to_alloc * buf_size;
         dm_ptr              = ucc_malloc(dm_attr.length, "memic_host");
         if (!dm_ptr) {
-            tl_error(lib, " memic_host allocation failed");
+            tl_debug(lib, " memic_host allocation failed");
             return UCC_ERR_NO_MEMORY;
         }
 
         dm_mr = ibv_reg_mr(pd, dm_ptr, dm_attr.length,
                            IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
         if (!dm_mr) {
-            tl_error(lib, "failed to reg host memory");
+            tl_debug(lib, "failed to reg host memory");
             ucc_free(dm_ptr);
             return UCC_ERR_NO_MESSAGE;
         }
@@ -76,11 +146,11 @@ ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
     } else {
         attr.comp_mask = 0;
         if (ibv_query_device_ex(ib_ctx, NULL, &attr)) {
-            tl_error(lib, "failed to query device (errno=%d)", errno);
+            tl_debug(lib, "failed to query device (errno=%d)", errno);
             return UCC_ERR_NO_MESSAGE;
         }
         if (!attr.max_dm_size) {
-            tl_error(lib, "device doesn't support dm allocation");
+            tl_debug(lib, "device doesn't support dm allocation");
             return UCC_ERR_NO_RESOURCE;
         }
         max_chunks_to_alloc = min_chunks_to_alloc = *buf_num_p;
@@ -125,7 +195,7 @@ ucc_status_t ucc_tl_mlx5_dm_alloc_reg(struct ibv_context *ib_ctx,
                               IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                                   IBV_ACCESS_ZERO_BASED);
         if (!dm_mr) {
-            tl_error(lib, "failed to reg memic");
+            tl_debug(lib, "failed to reg memic");
             ibv_free_dm(dm_ptr);
             return UCC_ERR_NO_MESSAGE;
         }
@@ -143,13 +213,16 @@ ucc_status_t ucc_tl_mlx5_dm_init(ucc_tl_mlx5_team_t *team)
     ucc_tl_mlx5_lib_config_t *cfg = &UCC_TL_MLX5_TEAM_LIB(team)->cfg;
     ucc_status_t              status;
 
+    status = ucc_tl_mlx5_alltoall_atomic_alloc(team);
+    if (UCC_OK != status) {
+        return status;
+    }
+
     status = ucc_tl_mlx5_dm_alloc_reg(
         ctx->shared_ctx, ctx->shared_pd, cfg->dm_host, cfg->dm_buf_size,
         &cfg->dm_buf_num, &team->dm_ptr, &team->dm_mr, UCC_TL_TEAM_LIB(team));
     if (status != UCC_OK) {
-        tl_debug(UCC_TL_TEAM_LIB(team),
-                 "failed to alloc and register device memory");
-        return status;
+        goto err_dm_alloc;
     }
     team->dm_offset = NULL;
 
@@ -158,9 +231,20 @@ ucc_status_t ucc_tl_mlx5_dm_init(ucc_tl_mlx5_team_t *team)
         UCC_CACHE_LINE_SIZE, 1, cfg->dm_buf_num, &ucc_tl_mlx5_dm_ops,
         ctx->super.super.ucc_context->thread_mode, "mlx5 dm pool");
     if (status != UCC_OK) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to init dm pool");
-        ucc_tl_mlx5_dm_cleanup(team);
-        return status;
+        tl_debug(UCC_TL_TEAM_LIB(team), "failed to init dm pool");
+        goto err_mpool_init;
     }
     return UCC_OK;
+
+err_mpool_init:
+    ibv_dereg_mr(team->dm_mr);
+    if (UCC_TL_MLX5_TEAM_LIB(team)->cfg.dm_host) {
+        ucc_free(team->dm_ptr);
+    } else {
+        ibv_free_dm(team->dm_ptr);
+    }
+    team->dm_ptr = NULL;
+err_dm_alloc:
+    ucc_tl_mlx5_alltoall_atomic_free(team);
+    return status;
 }

--- a/src/components/tl/mlx5/tl_mlx5_ib.c
+++ b/src/components/tl/mlx5/tl_mlx5_ib.c
@@ -74,7 +74,7 @@ ucc_status_t ucc_tl_mlx5_create_ibv_ctx(char               **ib_devname,
             }
         }
         if (!dev_list[i]) {
-            tl_error(lib, "IB device %s not found", *ib_devname);
+            tl_debug(lib, "IB device %s not found", *ib_devname);
             status = UCC_ERR_NOT_FOUND;
             goto out;
         }
@@ -129,7 +129,7 @@ ucc_status_t ucc_tl_mlx5_qp_connect(struct ibv_qp *qp, uint32_t qp_num,
     if (ibv_modify_qp(qp, &qp_attr,
                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                           IBV_QP_ACCESS_FLAGS) != 0) {
-        tl_error(lib, "QP RESET->INIT failed, %m");
+        tl_debug(lib, "QP RESET->INIT failed, %m");
         return UCC_ERR_NO_MESSAGE;
     }
 
@@ -149,7 +149,7 @@ ucc_status_t ucc_tl_mlx5_qp_connect(struct ibv_qp *qp, uint32_t qp_num,
                       IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
                           IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
                           IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER)) {
-        tl_error(lib, "QP INIT->RTR failed, %m");
+        tl_debug(lib, "QP INIT->RTR failed, %m");
         return UCC_ERR_NO_MESSAGE;
     }
 
@@ -165,7 +165,7 @@ ucc_status_t ucc_tl_mlx5_qp_connect(struct ibv_qp *qp, uint32_t qp_num,
                       IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
                           IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
                           IBV_QP_MAX_QP_RD_ATOMIC)) {
-        tl_error(lib, "QP RTR->RTS failed, %m");
+        tl_debug(lib, "QP RTR->RTS failed, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     return UCC_OK;
@@ -213,21 +213,21 @@ ucc_status_t ucc_tl_mlx5_init_dct(struct ibv_pd *pd, struct ibv_context *ctx,
 
     qp = mlx5dv_create_qp(ctx, &attr_ex, &attr_dv);
     if (qp == NULL) {
-        tl_error(lib, "couldn't create DCT QP, %m");
+        tl_debug(lib, "couldn't create DCT QP, %m");
         return UCC_ERR_NO_MESSAGE;
     }
 
     if (ibv_modify_qp(qp, &qp_attr_to_init,
                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
                           IBV_QP_ACCESS_FLAGS) != 0) {
-        tl_error(lib, "failed to modify init qp, %m");
+        tl_debug(lib, "failed to modify init qp, %m");
         goto fail;
     }
 
     if (ibv_modify_qp(qp, &qp_attr_to_rtr,
                       IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_AV |
                           IBV_QP_MIN_RNR_TIMER) != 0) {
-        tl_error(lib, "failed to modify init qp, %m");
+        tl_debug(lib, "failed to modify init qp, %m");
         goto fail;
     }
 
@@ -237,7 +237,7 @@ ucc_status_t ucc_tl_mlx5_init_dct(struct ibv_pd *pd, struct ibv_context *ctx,
 
 fail:
     if (ibv_destroy_qp(qp)) {
-        tl_error(lib, "couldn't destroy QP, %m");
+        tl_debug(lib, "couldn't destroy QP, %m");
     }
     return UCC_ERR_NO_MESSAGE;
 }
@@ -299,30 +299,30 @@ ucc_status_t ucc_tl_mlx5_init_dci(ucc_tl_mlx5_dci_t *dci, struct ibv_pd *pd,
 
     dci->dci_qp = mlx5dv_create_qp(ctx, &attr_ex, &attr_dv);
     if (!dci->dci_qp) {
-        tl_error(lib, "couldn't create DCI QP, %m");
+        tl_debug(lib, "couldn't create DCI QP, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     // Turn DCI ibv_qp to ibv_qpex and ibv_mqpex
     dci->dc_qpex = ibv_qp_to_qp_ex(dci->dci_qp);
     if (!dci->dc_qpex) {
-        tl_error(lib, "failed turn ibv_qp to ibv_qp_ex, %m");
+        tl_debug(lib, "failed turn ibv_qp to ibv_qp_ex, %m");
         goto fail;
     }
     dci->dc_mqpex = mlx5dv_qp_ex_from_ibv_qp_ex(dci->dc_qpex);
     if (!dci->dc_mqpex) {
-        tl_error(lib, "failed turn ibv_qp_ex to mlx5dv_qp_ex, %m");
+        tl_debug(lib, "failed turn ibv_qp_ex to mlx5dv_qp_ex, %m");
         goto fail;
     }
 
     if (ibv_modify_qp(dci->dci_qp, &qp_attr_to_init,
                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT) != 0) {
-        tl_error(lib, "failed to modify init qp, %m");
+        tl_debug(lib, "failed to modify init qp, %m");
         goto fail;
     }
 
     if (ibv_modify_qp(dci->dci_qp, &qp_attr_to_rtr,
                       IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_AV) != 0) {
-        tl_error(lib, "failed to modify qp to rtr, %m");
+        tl_debug(lib, "failed to modify qp to rtr, %m");
         goto fail;
     }
 
@@ -330,7 +330,7 @@ ucc_status_t ucc_tl_mlx5_init_dci(ucc_tl_mlx5_dci_t *dci, struct ibv_pd *pd,
                       IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
                       IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
                       IBV_QP_MAX_QP_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER) != 0) {
-        tl_error(lib, "failed to modify qp to rts, %m");
+        tl_debug(lib, "failed to modify qp to rts, %m");
         goto fail;
     }
 
@@ -338,7 +338,7 @@ ucc_status_t ucc_tl_mlx5_init_dci(ucc_tl_mlx5_dci_t *dci, struct ibv_pd *pd,
 
 fail:
     if (ibv_destroy_qp(dci->dci_qp)) {
-        tl_error(lib, "couldn't destroy qp, %m");
+        tl_debug(lib, "couldn't destroy qp, %m");
     }
     return UCC_ERR_NO_MESSAGE;
 }
@@ -371,7 +371,7 @@ ucc_status_t ucc_tl_mlx5_create_rc_qp(struct ibv_context *ctx,
 
     qp->qp = mlx5dv_create_qp(ctx, &attr_ex, &attr_dv);
     if (!qp->qp) {
-        tl_error(lib, "failed to create RC QP, %m");
+        tl_debug(lib, "failed to create RC QP, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     qp->qp_ex = ibv_qp_to_qp_ex(qp->qp);
@@ -395,7 +395,7 @@ ucc_status_t ucc_tl_mlx5_create_ah(struct ibv_pd *pd, uint16_t lid,
 
     *ah_ptr = ibv_create_ah(pd, &ah_attr);
     if (!(*ah_ptr)) {
-        tl_error(lib, "failed to create ah, %m");
+        tl_debug(lib, "failed to create ah, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     return UCC_OK;
@@ -448,18 +448,18 @@ ucc_status_t ucc_tl_mlx5_create_umr_qp(struct ibv_context *ctx,
     } while (*qp == NULL && umr_init_attr_ex.cap.max_inline_data > 0);
 
     if (*qp == NULL) {
-        tl_error(lib, "failed to create UMR QP with inline_data, %m");
+        tl_debug(lib, "failed to create UMR QP with inline_data, %m");
         return UCC_ERR_NO_MESSAGE;
     }
     qp_ex = ibv_qp_to_qp_ex(*qp);
     if (qp_ex == NULL) {
-        tl_error(lib, "failed to create UMR qp_ex, %m");
+        tl_debug(lib, "failed to create UMR qp_ex, %m");
         status = UCC_ERR_NO_MESSAGE;
         goto failure;
     }
     qp_ex->wr_flags = IBV_SEND_INLINE | IBV_SEND_SIGNALED;
     if (ibv_query_port(ctx, ib_port, &port_attr)) {
-        tl_error(lib, "failed to get port info, %m");
+        tl_debug(lib, "failed to get port info, %m");
         status = UCC_ERR_NO_MESSAGE;
         goto failure;
     }
@@ -476,7 +476,7 @@ ucc_status_t ucc_tl_mlx5_create_umr_qp(struct ibv_context *ctx,
 
 failure:
     if (ibv_destroy_qp(*qp)) {
-        tl_error(lib, "failed to destroy UMR QP, %m");
+        tl_debug(lib, "failed to destroy UMR QP, %m");
     }
     return status;
 }

--- a/src/components/tl/mlx5/tl_mlx5_pd.c
+++ b/src/components/tl/mlx5/tl_mlx5_pd.c
@@ -127,7 +127,7 @@ out:
 
 static ucc_status_t client_recv_data(int *shared_cmd_fd,
                                      uint32_t *shared_pd_handle,
-                                     const char *sock_path,
+                                     const char *sock_path, int *sock_p,
                                      ucc_tl_mlx5_lib_t *lib)
 {
     struct sockaddr_storage sockaddr = {};
@@ -159,7 +159,8 @@ static ucc_status_t client_recv_data(int *shared_cmd_fd,
         goto out;
     }
 
-    return status;
+    *sock_p = sock;
+    return UCC_OK;
 
 out:
     if (close(sock) == -1) {
@@ -229,7 +230,8 @@ ucc_status_t ucc_tl_mlx5_share_ctx_pd(ucc_tl_mlx5_context_t *ctx,
     ucc_status_t status;
 
     if (!is_ctx_owner) {
-        status = client_recv_data(&ctx_fd, &pd_handle, sock_path, lib);
+        status =
+            client_recv_data(&ctx_fd, &pd_handle, sock_path, &ctx->sock, lib);
         if (UCC_OK != status) {
             tl_debug(lib, "failed to share ctx & pd from client side");
             return status;

--- a/src/components/tl/mlx5/tl_mlx5_team.c
+++ b/src/components/tl/mlx5/tl_mlx5_team.c
@@ -6,7 +6,6 @@
 
 #include "tl_mlx5_coll.h"
 #include "tl_mlx5.h"
-#include "tl_mlx5_dm.h"
 #include "tl_mlx5_coll.h"
 #include "coll_score/ucc_coll_score.h"
 #include "alltoall/alltoall.h"
@@ -22,7 +21,7 @@ static ucc_status_t ucc_tl_mlx5_topo_init(ucc_tl_mlx5_team_t *team)
     status = ucc_ep_map_create_nested(&UCC_TL_CORE_TEAM(team)->ctx_map,
                                       &UCC_TL_TEAM_MAP(team), &team->ctx_map);
     if (UCC_OK != status) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to create ctx map");
+        tl_debug(UCC_TL_TEAM_LIB(team), "failed to create ctx map");
         return status;
     }
     subset.map    = team->ctx_map;
@@ -31,7 +30,7 @@ static ucc_status_t ucc_tl_mlx5_topo_init(ucc_tl_mlx5_team_t *team)
     status = ucc_topo_init(subset, UCC_TL_CORE_CTX(team)->topo, &team->topo);
 
     if (UCC_OK != status) {
-        tl_error(UCC_TL_TEAM_LIB(team), "failed to init team topo");
+        tl_debug(UCC_TL_TEAM_LIB(team), "failed to init team topo");
         goto err_topo_init;
     }
 
@@ -41,10 +40,14 @@ err_topo_init:
     return status;
 }
 
-static void ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team)
+void ucc_tl_mlx5_topo_cleanup(ucc_tl_mlx5_team_t *team)
 {
+    if (!team->topo) {
+        return;
+    }
     ucc_ep_map_destroy_nested(&team->ctx_map);
     ucc_topo_cleanup(team->topo);
+    team->topo = NULL;
 }
 
 UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
@@ -56,33 +59,26 @@ UCC_CLASS_INIT_FUNC(ucc_tl_mlx5_team_t, ucc_base_context_t *tl_context,
 
     UCC_CLASS_CALL_SUPER_INIT(ucc_tl_team_t, &ctx->super, params);
 
-    self->a2a    = NULL;
-    self->dm_ptr = NULL;
-
     status = ucc_tl_mlx5_topo_init(self);
     if (status != UCC_OK) {
-        tl_error(ctx->super.super.lib, "failed to init team topo");
+        tl_debug(ctx->super.super.lib, "failed to init team topo");
         return status;
     }
 
-    if (ucc_topo_get_sbgp(self->topo, UCC_SBGP_NODE)->group_rank ==
-        MLX5_ASR_RANK) {
-        status = ucc_tl_mlx5_dm_init(self);
-        if (UCC_OK != status) {
-            tl_debug(UCC_TL_TEAM_LIB(self), "failed to init device memory");
-        }
+    self->a2a = NULL;
+    status    = ucc_tl_mlx5_team_init_alltoall(self);
+    if (UCC_OK != status) {
+        return status;
     }
-
-    self->status[0] = status;
-    self->state     = TL_MLX5_TEAM_STATE_INIT;
 
     self->mcast  = NULL;
     status = ucc_tl_mlx5_mcast_team_init(tl_context, &(self->mcast), &(ctx->mcast), params,
                                          &(UCC_TL_MLX5_TEAM_LIB(self)->cfg.mcast_conf));
-    if (ucc_unlikely(UCC_OK != status)) {
+    if (UCC_OK != status) {
         return status;
     }
 
+    self->state = TL_MLX5_TEAM_STATE_INIT;
     tl_debug(tl_context->lib, "posted tl team: %p", self);
     return UCC_OK;
 }
@@ -91,8 +87,8 @@ UCC_CLASS_CLEANUP_FUNC(ucc_tl_mlx5_team_t)
 {
     tl_debug(self->super.super.context->lib, "finalizing tl team: %p", self);
 
-    ucc_tl_mlx5_alltoall_cleanup(self);
     ucc_tl_mlx5_dm_cleanup(self);
+    ucc_tl_mlx5_alltoall_cleanup(self);
     ucc_tl_mlx5_topo_cleanup(self);
 }
 
@@ -117,10 +113,10 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
     switch (tl_team->state) {
     case TL_MLX5_TEAM_STATE_INIT:
         status = ucc_service_allreduce(
-                    core_team, &tl_team->status[0], &tl_team->status[1],
-                    UCC_DT_INT32, 1, UCC_OP_MIN, subset, &tl_team->scoll_req);
+            core_team, &tl_team->a2a_status.local, &tl_team->a2a_status.global,
+            UCC_DT_INT32, 1, UCC_OP_MIN, subset, &tl_team->scoll_req);
         if (status < 0) {
-            tl_error(UCC_TL_TEAM_LIB(tl_team),
+            tl_debug(UCC_TL_TEAM_LIB(tl_team),
                      "failed to collect global status");
             return status;
         }
@@ -128,7 +124,7 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
     case TL_MLX5_TEAM_STATE_POSTED:
         status = ucc_service_coll_test(tl_team->scoll_req);
         if (status < 0) {
-            tl_error(UCC_TL_TEAM_LIB(tl_team),
+            tl_debug(UCC_TL_TEAM_LIB(tl_team),
                      "failure during service coll exchange: %s",
                      ucc_status_string(status));
             return status;
@@ -136,33 +132,27 @@ ucc_status_t ucc_tl_mlx5_team_create_test(ucc_base_team_t *team)
         if (UCC_INPROGRESS == status) {
             return status;
         }
-        ucc_assert(status == UCC_OK);
         ucc_service_coll_finalize(tl_team->scoll_req);
-        if (tl_team->status[1] != UCC_OK) {
-            tl_debug(UCC_TL_TEAM_LIB(tl_team),
-                     "node leader failed during device memory init: %s",
-                     ucc_status_string(tl_team->status[1]));
-            ucc_tl_mlx5_team_destroy(team);
-            return tl_team->status[1];
-        }
         tl_team->state = TL_MLX5_TEAM_STATE_ALLTOALL_INIT;
     case TL_MLX5_TEAM_STATE_ALLTOALL_INIT:
-        status = ucc_tl_mlx5_team_alltoall_init_start(tl_team);
-        if (status != UCC_OK) {
-            tl_debug(UCC_TL_TEAM_LIB(tl_team), "failed to init a2a: %s",
-                     ucc_status_string(status));
-            return status;
-        }
+        tl_team->a2a_status.local =
+            ucc_tl_mlx5_team_test_alltoall_start(tl_team);
         tl_team->state = TL_MLX5_TEAM_STATE_ALLTOALL_POSTED;
     case TL_MLX5_TEAM_STATE_ALLTOALL_POSTED:
-        status = ucc_tl_mlx5_team_alltoall_init_progress(tl_team);
+        // coverity[deref_arg:FALSE]
+        tl_team->a2a_status.local =
+            ucc_tl_mlx5_team_test_alltoall_progress(tl_team);
+        if (UCC_INPROGRESS == tl_team->a2a_status.local) {
+            return UCC_INPROGRESS;
+        }
+        if (UCC_OK != tl_team->a2a_status.local) {
+            tl_debug(UCC_TL_TEAM_LIB(tl_team), "failed to init a2a: %s",
+                     ucc_status_string(tl_team->a2a_status.local));
+        }
     }
-    if (status < 0) {
-        tl_debug(team->context->lib, "failed creating tl team: %p", tl_team);
-    } else if (status == UCC_OK) {
-        tl_debug(team->context->lib, "initialized tl team: %p", tl_team);
-    }
-    return status;
+
+    tl_debug(team->context->lib, "initialized tl team: %p", tl_team);
+    return UCC_OK;
 }
 
 ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
@@ -178,33 +168,19 @@ ucc_status_t ucc_tl_mlx5_team_get_scores(ucc_base_team_t *  tl_team,
 
     team_info.alg_fn              = NULL;
     team_info.default_score       = UCC_TL_MLX5_DEFAULT_SCORE;
-    team_info.init                = NULL;
+    team_info.init                = ucc_tl_mlx5_coll_init;
     team_info.num_mem_types       = 2;
     team_info.supported_mem_types = mt;
-    team_info.supported_colls     = UCC_TL_MLX5_SUPPORTED_COLLS;
+    team_info.supported_colls =
+        (UCC_COLL_TYPE_ALLTOALL * (team->a2a_status.local == UCC_OK)) |
+        UCC_COLL_TYPE_BCAST;
     team_info.size                = UCC_TL_TEAM_SIZE(team);
 
-    status = ucc_coll_score_alloc(&score);
+    status = ucc_coll_score_build_default(
+        tl_team, UCC_TL_MLX5_DEFAULT_SCORE, ucc_tl_mlx5_coll_init,
+        UCC_TL_MLX5_SUPPORTED_COLLS, mt, 2, &score);
     if (UCC_OK != status) {
-        tl_error(lib, "failed to alloc score_t");
-        return status;
-    }
-
-    status = ucc_coll_score_add_range(
-        score, UCC_COLL_TYPE_ALLTOALL, UCC_MEMORY_TYPE_HOST, 0,
-        MAX_MSG_SIZE * UCC_TL_TEAM_SIZE(team), UCC_TL_MLX5_DEFAULT_SCORE,
-        ucc_tl_mlx5_coll_init, tl_team);
-    if (UCC_OK != status) {
-        tl_error(lib, "failed to add range to score_t");
-        return status;
-    }
-
-    status = ucc_coll_score_add_range(
-        score, UCC_COLL_TYPE_ALLTOALL, UCC_MEMORY_TYPE_CUDA, 0,
-        MAX_MSG_SIZE * UCC_TL_TEAM_SIZE(team), UCC_TL_MLX5_DEFAULT_SCORE,
-        ucc_tl_mlx5_coll_init, tl_team);
-    if (UCC_OK != status) {
-        tl_error(lib, "failed to add range to score_t");
+        tl_debug(lib, "failed to build score map");
         return status;
     }
 

--- a/src/components/tl/nccl/allgatherv/allgatherv.h
+++ b/src/components/tl/nccl/allgatherv/allgatherv.h
@@ -17,7 +17,7 @@ enum {
 };
 
 #define UCC_TL_NCCL_ALLGATHERV_DEFAULT_ALG_SELECT_STR          \
-    "allgatherv:cuda:0-16k:@0#allgatherv:cuda:16k-1M:@1#allgatherv:cuda:1M-inf:@2"
+    "allgatherv:cuda:0-16k:@0#allgatherv:cuda:16k-1M:@1#allgatherv:cuda:1M-inf:@2#allgatherv:cuda_managed:0-inf:@0"
 
 extern ucc_base_coll_alg_info_t
              ucc_tl_nccl_allgatherv_algs[UCC_TL_NCCL_ALLGATHERV_ALG_LAST + 1];

--- a/src/components/tl/nccl/tl_nccl_coll.c
+++ b/src/components/tl/nccl/tl_nccl_coll.c
@@ -459,11 +459,6 @@ ucc_status_t ucc_tl_nccl_allgather_init(ucc_tl_nccl_task_t *task)
 
 ucc_status_t ucc_tl_nccl_allgatherv_init(ucc_tl_nccl_task_t *task)
 {
-    if (UCC_IS_INPLACE(TASK_ARGS(task))) {
-        tl_error(UCC_TASK_LIB(task), "inplace allgatherv is not supported");
-        return UCC_ERR_NOT_SUPPORTED;
-    }
-
     task->super.post = ucc_tl_nccl_allgatherv_p2p_start;
     return UCC_OK;
 }

--- a/src/components/tl/self/tl_self_coll.c
+++ b/src/components/tl/self/tl_self_coll.c
@@ -70,10 +70,11 @@ void ucc_tl_self_copy_progress(ucc_coll_task_t *coll_task)
 
 ucc_status_t ucc_tl_self_copy_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_self_task_t *task = ucc_derived_of(coll_task, ucc_tl_self_task_t);
-    ucc_ee_executor_t  *exec;
-    ucc_ee_executor_task_args_t exec_args;
-    ucc_status_t                status;
+    ucc_tl_self_task_t         *task      = ucc_derived_of(coll_task,
+                                                           ucc_tl_self_task_t);
+    ucc_ee_executor_task_args_t exec_args = {0};
+    ucc_ee_executor_t *exec;
+    ucc_status_t       status;
 
     status = ucc_coll_task_get_executor(&task->super, &exec);
     if (ucc_unlikely(status != UCC_OK)) {

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -447,19 +447,16 @@ ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
 
     status = ucc_tl_sharp_context_init(sharp_ctx, &sharp_ctx->sharp_context,
                                        &sharp_ctx->oob_ctx, topo);
-    if (status != UCC_OK) {
-        ucc_topo_cleanup(topo);
-        return status;
-    }
-
     ucc_topo_cleanup(topo);
+    if (status != UCC_OK) {
+        goto err_sharp_ctx_init;
+    }
 
     if (sharp_ctx->cfg.use_rcache) {
         status = ucc_tl_sharp_rcache_create(sharp_ctx->sharp_context, &sharp_ctx->rcache);
         if (status != UCC_OK) {
             tl_error(sharp_ctx->super.super.lib, "failed to create rcache");
-            sharp_coll_finalize(sharp_ctx->sharp_context);
-            return UCC_ERR_NO_RESOURCE;
+            goto err_sharp_ctx_init;
         }
     }
 
@@ -468,10 +465,18 @@ ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
         sharp_ctx->sharp_context);
     if (status != UCC_OK) {
         tl_error(context->lib, "failed to register progress function");
-        return status;
+        goto err_sharp_progress_register;
     }
 
     return UCC_OK;
+
+err_sharp_progress_register:
+    if (sharp_ctx->rcache != NULL) {
+        ucc_rcache_destroy(sharp_ctx->rcache);
+    }
+err_sharp_ctx_init:
+    sharp_coll_finalize(sharp_ctx->sharp_context);
+    return status;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_sharp_context_t)

--- a/src/components/tl/sharp/tl_sharp_context.c
+++ b/src/components/tl/sharp/tl_sharp_context.c
@@ -449,7 +449,7 @@ ucc_status_t ucc_tl_sharp_context_create_epilog(ucc_base_context_t *context)
                                        &sharp_ctx->oob_ctx, topo);
     ucc_topo_cleanup(topo);
     if (status != UCC_OK) {
-        goto err_sharp_ctx_init;
+        return status;
     }
 
     if (sharp_ctx->cfg.use_rcache) {

--- a/src/components/tl/ucp/Makefile.am
+++ b/src/components/tl/ucp/Makefile.am
@@ -9,10 +9,11 @@ SUBDIRS = .
 include makefile.coll_plugins.am
 endif
 
-allgather =                       \
-	allgather/allgather.h         \
-	allgather/allgather.c         \
-	allgather/allgather_ring.c    \
+allgather =                        \
+	allgather/allgather.h          \
+	allgather/allgather.c          \
+	allgather/allgather_ring.c     \
+	allgather/allgather_neighbor.c \
 	allgather/allgather_knomial.c
 
 allgatherv =                     \

--- a/src/components/tl/ucp/allgather/allgather.c
+++ b/src/components/tl/ucp/allgather/allgather.c
@@ -7,6 +7,8 @@
 #include "tl_ucp.h"
 #include "allgather.h"
 
+#define ALLGATHER_MAX_PATTERN_SIZE (sizeof(UCC_TL_UCP_ALLGATHER_DEFAULT_ALG_SELECT_STR))
+
 ucc_base_coll_alg_info_t
     ucc_tl_ucp_allgather_algs[UCC_TL_UCP_ALLGATHER_ALG_LAST + 1] = {
         [UCC_TL_UCP_ALLGATHER_ALG_KNOMIAL] =
@@ -17,10 +19,27 @@ ucc_base_coll_alg_info_t
             {.id   = UCC_TL_UCP_ALLGATHER_ALG_RING,
              .name = "ring",
              .desc = "O(N) Ring"},
+        [UCC_TL_UCP_ALLGATHER_ALG_NEIGHBOR] =
+            {.id   = UCC_TL_UCP_ALLGATHER_ALG_NEIGHBOR,
+             .name = "neighbor",
+             .desc = "O(N) Neighbor Exchange N/2 steps"},
         [UCC_TL_UCP_ALLGATHER_ALG_LAST] = {
             .id = 0, .name = NULL, .desc = NULL}};
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task)
 {
     return ucc_tl_ucp_allgather_ring_init_common(task);
+}
+
+char *ucc_tl_ucp_allgather_score_str_get(ucc_tl_ucp_team_t *team)
+{
+    int   max_size = ALLGATHER_MAX_PATTERN_SIZE;
+    int   algo_num = UCC_TL_TEAM_SIZE(team) % 2
+                         ? UCC_TL_UCP_ALLGATHER_ALG_RING
+                         : UCC_TL_UCP_ALLGATHER_ALG_NEIGHBOR;
+    char *str      = ucc_malloc(max_size * sizeof(char));
+
+    ucc_snprintf_safe(str, max_size,
+                      UCC_TL_UCP_ALLGATHER_DEFAULT_ALG_SELECT_STR, algo_num);
+    return str;
 }

--- a/src/components/tl/ucp/allgather/allgather.h
+++ b/src/components/tl/ucp/allgather/allgather.h
@@ -11,14 +11,17 @@
 enum {
     UCC_TL_UCP_ALLGATHER_ALG_KNOMIAL,
     UCC_TL_UCP_ALLGATHER_ALG_RING,
+    UCC_TL_UCP_ALLGATHER_ALG_NEIGHBOR,
     UCC_TL_UCP_ALLGATHER_ALG_LAST
 };
 
 extern ucc_base_coll_alg_info_t
-             ucc_tl_ucp_allgather_algs[UCC_TL_UCP_ALLGATHER_ALG_LAST + 1];
+    ucc_tl_ucp_allgather_algs[UCC_TL_UCP_ALLGATHER_ALG_LAST + 1];
 
 #define UCC_TL_UCP_ALLGATHER_DEFAULT_ALG_SELECT_STR                            \
-    "allgather:0-4k:@0#allgather:4k-inf:@1"
+    "allgather:0-4k:@0#allgather:4k-inf:@%d"
+
+char *ucc_tl_ucp_allgather_score_str_get(ucc_tl_ucp_team_t *team);
 
 static inline int ucc_tl_ucp_allgather_alg_from_str(const char *str)
 {
@@ -33,20 +36,30 @@ static inline int ucc_tl_ucp_allgather_alg_from_str(const char *str)
 
 ucc_status_t ucc_tl_ucp_allgather_init(ucc_tl_ucp_task_t *task);
 
+/* Ring */
 ucc_status_t ucc_tl_ucp_allgather_ring_init(ucc_base_coll_args_t *coll_args,
-                                            ucc_base_team_t *     team,
-                                            ucc_coll_task_t **    task_h);
+                                            ucc_base_team_t      *team,
+                                            ucc_coll_task_t     **task_h);
 
 ucc_status_t ucc_tl_ucp_allgather_ring_init_common(ucc_tl_ucp_task_t *task);
 
-void  ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
+void ucc_tl_ucp_allgather_ring_progress(ucc_coll_task_t *task);
 
 ucc_status_t ucc_tl_ucp_allgather_ring_start(ucc_coll_task_t *task);
 
+/* Neighbor Exchange */
+ucc_status_t ucc_tl_ucp_allgather_neighbor_init(ucc_base_coll_args_t *coll_args,
+                                                ucc_base_team_t      *team,
+                                                ucc_coll_task_t     **task_h);
+
+void ucc_tl_ucp_allgather_neighbor_progress(ucc_coll_task_t *task);
+
+ucc_status_t ucc_tl_ucp_allgather_neighbor_start(ucc_coll_task_t *task);
+
 /* Uses allgather_kn_radix from config */
 ucc_status_t ucc_tl_ucp_allgather_knomial_init(ucc_base_coll_args_t *coll_args,
-                                               ucc_base_team_t *     team,
-                                               ucc_coll_task_t **    task_h);
+                                               ucc_base_team_t      *team,
+                                               ucc_coll_task_t     **task_h);
 
 /* Internal interface with custom radix */
 ucc_status_t ucc_tl_ucp_allgather_knomial_init_r(

--- a/src/components/tl/ucp/allgather/allgather_knomial.c
+++ b/src/components/tl/ucp/allgather/allgather_knomial.c
@@ -167,19 +167,20 @@ out:
 
 ucc_status_t ucc_tl_ucp_allgather_knomial_start(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t       *args  = &TASK_ARGS(task);
-    ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
-    ucc_coll_type_t        ct    = args->coll_type;
-    ucc_rank_t             size  = UCC_TL_TEAM_SIZE(team);
-    ucc_kn_radix_t         radix = task->allgather_kn.p.radix;
-    ucc_knomial_pattern_t *p     = &task->allgather_kn.p;
-    ucc_rank_t             rank  = VRANK(UCC_TL_TEAM_RANK(team),
-                                     ct == UCC_COLL_TYPE_BCAST ? args->root : 0,
-                                     size);
+    ucc_tl_ucp_task_t          *task  = ucc_derived_of(coll_task,
+                                                       ucc_tl_ucp_task_t);
+    ucc_coll_args_t            *args  = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t          *team  = TASK_TEAM(task);
+    ucc_coll_type_t             ct    = args->coll_type;
+    ucc_rank_t                  size  = UCC_TL_TEAM_SIZE(team);
+    ucc_kn_radix_t              radix = task->allgather_kn.p.radix;
+    ucc_knomial_pattern_t      *p     = &task->allgather_kn.p;
+    ucc_rank_t                  rank  = VRANK(UCC_TL_TEAM_RANK(team),
+                                              ct == UCC_COLL_TYPE_BCAST ?
+                                              args->root : 0, size);
+    ucc_ee_executor_task_args_t eargs = {0};
     ucc_status_t       status;
     ptrdiff_t          offset;
-    ucc_ee_executor_task_args_t eargs;
     ucc_ee_executor_t *exec;
 
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_kn_start", 0);

--- a/src/components/tl/ucp/allgather/allgather_neighbor.c
+++ b/src/components/tl/ucp/allgather/allgather_neighbor.c
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * See file LICENSE for terms.
+ */
+#include "config.h"
+#include "tl_ucp.h"
+#include "allgather.h"
+#include "core/ucc_progress_queue.h"
+#include "tl_ucp_sendrecv.h"
+#include "utils/ucc_math.h"
+#include "utils/ucc_coll_utils.h"
+#include "components/mc/ucc_mc.h"
+
+static ucc_rank_t get_recv_from_rank(ucc_rank_t rank, ucc_rank_t size, int i)
+{
+    const int  i_parity = i % 2;
+    ucc_rank_t offset_at_step[2], recv_data_from;
+    if (rank % 2) {
+        recv_data_from    = (rank - 1 + size) % size;
+        offset_at_step[0] = (-2);
+        offset_at_step[1] = (+2);
+    } else {
+        recv_data_from    = rank;
+        offset_at_step[0] = (+2);
+        offset_at_step[1] = (-2);
+    }
+
+    return (recv_data_from + offset_at_step[i_parity] * ucc_div_round_up(i, 2) +
+            size) %
+           size;
+}
+
+ucc_status_t ucc_tl_ucp_allgather_neighbor_init(ucc_base_coll_args_t *coll_args,
+                                                ucc_base_team_t      *team,
+                                                ucc_coll_task_t     **task_h)
+{
+    ucc_status_t       status = UCC_OK;
+    ucc_tl_ucp_task_t *task;
+    ucc_tl_ucp_team_t *ucp_team;
+
+    task     = ucc_tl_ucp_init_task(coll_args, team);
+    ucp_team = TASK_TEAM(task);
+
+    if (!ucc_coll_args_is_predefined_dt(&TASK_ARGS(task), UCC_RANK_INVALID)) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
+        status = UCC_ERR_NOT_SUPPORTED;
+        goto out;
+    }
+
+    if (UCC_TL_TEAM_SIZE(ucp_team) % 2) {
+        tl_debug(UCC_TASK_LIB(task),
+                 "odd team size is not supported, switching to ring");
+        status = ucc_tl_ucp_allgather_ring_init_common(task);
+    } else {
+        task->super.post     = ucc_tl_ucp_allgather_neighbor_start;
+        task->super.progress = ucc_tl_ucp_allgather_neighbor_progress;
+    }
+
+out:
+    if (status != UCC_OK) {
+        ucc_tl_ucp_put_task(task);
+        return status;
+    }
+
+    *task_h = &task->super;
+    return status;
+}
+
+/* Original implementation: https://github.com/open-mpi/ompi/blob/main/ompi/mca/coll/base/coll_base_allgather.c */
+void ucc_tl_ucp_allgather_neighbor_progress(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    ucc_rank_t         trank     = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         tsize     = UCC_TL_TEAM_SIZE(team);
+    void              *rbuf      = TASK_ARGS(task).dst.info.buffer;
+    ucc_memory_type_t  rmem      = TASK_ARGS(task).dst.info.mem_type;
+    ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
+    size_t             count     = TASK_ARGS(task).dst.info.count;
+    size_t             data_size = (count / tsize) * ucc_dt_size(dt);
+    ucc_rank_t         neighbors[2], i;
+    int                i_parity, even_rank;
+    void              *tmprecv, *tmpsend;
+
+    if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+        return;
+    }
+
+    even_rank = !(trank % 2);
+    if (even_rank) {
+        neighbors[0] = (trank + 1) % tsize;
+        neighbors[1] = (trank - 1 + tsize) % tsize;
+    } else {
+        neighbors[0] = (trank - 1 + tsize) % tsize;
+        neighbors[1] = (trank + 1) % tsize;
+    }
+
+    while (task->tagged.send_posted < (tsize / 2)) {
+        i        = task->tagged.send_posted;
+        i_parity = i % 2;
+
+        tmprecv =
+            PTR_OFFSET(rbuf, get_recv_from_rank(trank, tsize, i) * data_size);
+        tmpsend = PTR_OFFSET(rbuf, get_recv_from_rank(trank, tsize, i - 1) *
+                                       data_size);
+
+        /* Sendreceive */
+        UCPCHECK_GOTO(ucc_tl_ucp_send_nb(tmpsend, 2 * data_size, rmem,
+                                         neighbors[i_parity], team, task),
+                      task, out);
+        UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(tmprecv, 2 * data_size, rmem,
+                                         neighbors[i_parity], team, task),
+                      task, out);
+
+        if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
+            return;
+        }
+    }
+
+    ucc_assert(UCC_TL_UCP_TASK_P2P_COMPLETE(task));
+    task->super.status = UCC_OK;
+
+out:
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_neighbor_done",
+                                     0);
+}
+
+ucc_status_t ucc_tl_ucp_allgather_neighbor_start(ucc_coll_task_t *coll_task)
+{
+    ucc_tl_ucp_task_t *task      = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
+    ucc_tl_ucp_team_t *team      = TASK_TEAM(task);
+    size_t             count     = TASK_ARGS(task).dst.info.count;
+    void              *sbuf      = TASK_ARGS(task).src.info.buffer;
+    void              *rbuf      = TASK_ARGS(task).dst.info.buffer;
+    ucc_memory_type_t  smem      = TASK_ARGS(task).src.info.mem_type;
+    ucc_memory_type_t  rmem      = TASK_ARGS(task).dst.info.mem_type;
+    ucc_datatype_t     dt        = TASK_ARGS(task).dst.info.datatype;
+    ucc_rank_t         trank     = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t         tsize     = UCC_TL_TEAM_SIZE(team);
+    size_t             data_size = (count / tsize) * ucc_dt_size(dt);
+    ucc_status_t       status;
+    ucc_rank_t         neighbor;
+    void              *tmprecv, *tmpsend;
+
+    UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_allgather_neighbor_start",
+                                     0);
+    ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
+
+    if (!UCC_IS_INPLACE(TASK_ARGS(task))) {
+        status = ucc_mc_memcpy(PTR_OFFSET(rbuf, data_size * trank), sbuf,
+                               data_size, rmem, smem);
+        if (ucc_unlikely(UCC_OK != status)) {
+            return status;
+        }
+    }
+
+    if (trank % 2) {
+        neighbor = (trank - 1 + tsize) % tsize;
+    } else {
+        neighbor = (trank + 1) % tsize;
+    }
+
+    tmprecv = PTR_OFFSET(rbuf, neighbor * data_size);
+    tmpsend = PTR_OFFSET(rbuf, trank * data_size);
+
+    /* Sendreceive */
+    UCPCHECK_GOTO(
+        ucc_tl_ucp_send_nb(tmpsend, data_size, rmem, neighbor, team, task),
+        task, out);
+    UCPCHECK_GOTO(
+        ucc_tl_ucp_recv_nb(tmprecv, data_size, rmem, neighbor, team, task),
+        task, out);
+out:
+    return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
+}

--- a/src/components/tl/ucp/allgather/allgather_ring.c
+++ b/src/components/tl/ucp/allgather/allgather_ring.c
@@ -143,6 +143,7 @@ ucc_status_t ucc_tl_ucp_allgather_ring_init(ucc_base_coll_args_t *coll_args,
     status = ucc_tl_ucp_allgather_ring_init_common(task);
     if (status != UCC_OK) {
         ucc_tl_ucp_put_task(task);
+        return status;
     }
     *task_h = &task->super;
     return UCC_OK;

--- a/src/components/tl/ucp/allgatherv/allgatherv.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv.c
@@ -9,10 +9,6 @@
 #include "allgatherv.h"
 #include "utils/ucc_coll_utils.h"
 
-ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *task);
-
-void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *task);
-
 ucc_base_coll_alg_info_t
     ucc_tl_ucp_allgatherv_algs[UCC_TL_UCP_ALLGATHERV_ALG_LAST + 1] = {
         [UCC_TL_UCP_ALLGATHERV_ALG_RING] =
@@ -29,8 +25,5 @@ ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task)
         return UCC_ERR_NOT_SUPPORTED;
     }
 
-    task->super.post     = ucc_tl_ucp_allgatherv_ring_start;
-    task->super.progress = ucc_tl_ucp_allgatherv_ring_progress;
-
-    return UCC_OK;
+    return ucc_tl_ucp_allgatherv_ring_init_common(task);
 }

--- a/src/components/tl/ucp/allgatherv/allgatherv.h
+++ b/src/components/tl/ucp/allgatherv/allgatherv.h
@@ -18,6 +18,7 @@ enum {
 extern ucc_base_coll_alg_info_t
              ucc_tl_ucp_allgatherv_algs[UCC_TL_UCP_ALLGATHERV_ALG_LAST + 1];
 
-ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task);
+ucc_status_t ucc_tl_ucp_allgatherv_ring_init_common(ucc_tl_ucp_task_t *task);
 
+ucc_status_t ucc_tl_ucp_allgatherv_init(ucc_tl_ucp_task_t *task);
 #endif

--- a/src/components/tl/ucp/allgatherv/allgatherv_ring.c
+++ b/src/components/tl/ucp/allgatherv/allgatherv_ring.c
@@ -17,21 +17,26 @@ void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
     ucc_coll_args_t   *args     = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
-    ucc_rank_t         grank    = UCC_TL_TEAM_RANK(team);
-    ucc_rank_t         gsize    = UCC_TL_TEAM_SIZE(team);
+    ucc_rank_t         trank    = task->subset.myrank;
+    ucc_rank_t         tsize    = (ucc_rank_t)task->subset.map.ep_num;
     ptrdiff_t          rbuf     = (ptrdiff_t)args->dst.info_v.buffer;
     ucc_memory_type_t  rmem     = args->dst.info_v.mem_type;
     size_t             rdt_size = ucc_dt_size(args->dst.info_v.datatype);
-    ucc_rank_t         sendto   = (grank + 1) % gsize;
-    ucc_rank_t         recvfrom = (grank - 1 + gsize) % gsize;
-    ucc_rank_t         send_idx, recv_idx;
+    ucc_rank_t         send_idx, recv_idx, sendto, recvfrom;
     size_t             data_size, data_displ;
 
     if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
         return;
     }
-    while (task->tagged.send_posted < gsize) {
-        send_idx   = (grank - task->tagged.send_posted + 1 + gsize) % gsize;
+
+    sendto   = ucc_ep_map_eval(task->subset.map, (trank + 1) % tsize);
+    recvfrom = ucc_ep_map_eval(task->subset.map, (trank - 1 + tsize) % tsize);
+
+    while (task->tagged.send_posted < tsize) {
+        send_idx   =
+            ucc_ep_map_eval(task->subset.map, (trank -
+                                               task->tagged.send_posted + 1 +
+                                               tsize) % tsize);
         data_displ = ucc_coll_args_get_displacement(
                          args, args->dst.info_v.displacements, send_idx) *
                      rdt_size;
@@ -41,7 +46,10 @@ void ucc_tl_ucp_allgatherv_ring_progress(ucc_coll_task_t *coll_task)
         UCPCHECK_GOTO(ucc_tl_ucp_send_nb((void *)(rbuf + data_displ), data_size,
                                          rmem, sendto, team, task),
                       task, out);
-        recv_idx   = (grank - task->tagged.recv_posted + gsize) % gsize;
+        recv_idx   =
+            ucc_ep_map_eval(task->subset.map, (trank -
+                                               task->tagged.recv_posted +
+                                               tsize) % tsize);
         data_displ = ucc_coll_args_get_displacement(
                          args, args->dst.info_v.displacements, recv_idx) *
                      rdt_size;
@@ -97,4 +105,26 @@ ucc_status_t ucc_tl_ucp_allgatherv_ring_start(ucc_coll_task_t *coll_task)
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);
 error:
     return task->super.status;
+}
+
+ucc_status_t ucc_tl_ucp_allgatherv_ring_init_common(ucc_tl_ucp_task_t *task)
+{
+    ucc_tl_ucp_team_t *team = TASK_TEAM(task);
+    ucc_sbgp_t *sbgp;
+
+    if (!ucc_coll_args_is_predefined_dt(&TASK_ARGS(task), UCC_RANK_INVALID)) {
+        tl_error(UCC_TASK_LIB(task), "user defined datatype is not supported");
+        return UCC_ERR_NOT_SUPPORTED;
+    }
+
+    if (team->cfg.use_reordering) {
+        sbgp = ucc_topo_get_sbgp(team->topo, UCC_SBGP_FULL_HOST_ORDERED);
+        task->subset.myrank = sbgp->group_rank;
+        task->subset.map    = sbgp->map;
+    }
+
+    task->super.post     = ucc_tl_ucp_allgatherv_ring_start;
+    task->super.progress = ucc_tl_ucp_allgatherv_ring_progress;
+
+    return UCC_OK;
 }

--- a/src/components/tl/ucp/alltoallv/alltoallv_hybrid.c
+++ b/src/components/tl/ucp/alltoallv/alltoallv_hybrid.c
@@ -303,7 +303,6 @@ static size_t pack_send_data(ucc_tl_ucp_task_t *task, int step,
     int                n                    = send_count;
     int                logi                 = 1;
     void              *op_metadata          = task->alltoallv_hybrid.scratch_mc_header->addr;
-
     ucc_rank_t index;
     int send_len, snd_offset, i, k;
     unsigned int temp_count;
@@ -365,7 +364,7 @@ static size_t pack_send_data(ucc_tl_ucp_task_t *task, int step,
     /* if there is data for less than half the destinations, send meta data
      * in sparse format.
      */
-    if ((sparse_cnt / 2) < send_count) {
+    if ((sparse_cnt * 2) < send_count) {
         /* sparse format: store nonzero messages and source rank index */
         ((unsigned int *)packed_send_buf)[0] = sparse_cnt;
         /* compute space requirement for sparse data exchange header */

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -15,6 +15,23 @@
         task->reduce_scatter_kn.phase = _phase;                                \
     } while (0)
 
+static inline void get_sbuf_rbuf(ucc_knomial_pattern_t *p, ucc_coll_args_t *args,
+                                 void *scratch, size_t block_count,
+                                 void **sbuf, void **rbuf)
+{
+    uint8_t node_type = p->node_type;
+    size_t  dt_size   = ucc_dt_size(args->dst.info.datatype);
+
+    if (ucc_knomial_pattern_loop_first_iteration(p)) {
+        *sbuf = (KN_NODE_PROXY == node_type || UCC_IS_INPLACE(*args))
+                 ? args->dst.info.buffer: args->src.info.buffer;
+        *rbuf = scratch;
+    } else {
+        *sbuf = scratch;
+        *rbuf = PTR_OFFSET(*sbuf, block_count * dt_size);
+    }
+}
+
 void ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t          *task       = ucc_derived_of(coll_task,
@@ -23,7 +40,7 @@ void ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t          *team       = TASK_TEAM(task);
     ucc_kn_radix_t              radix      = task->reduce_scatter_kn.p.radix;
     int                         avg_pre_op =
-        UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
+    UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
     uint8_t                     node_type  =
         task->reduce_scatter_kn.p.node_type;
     ucc_knomial_pattern_t      *p          = &task->reduce_scatter_kn.p;
@@ -33,24 +50,22 @@ void ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
     size_t                      count      = args->dst.info.count;
     ucc_datatype_t              dt         = args->dst.info.datatype;
     void                       *sbuf       = UCC_IS_INPLACE(*args) ?
-        rbuf : args->src.info.buffer;
+                                             rbuf : args->src.info.buffer;
     size_t                      dt_size    = ucc_dt_size(dt);
     size_t                      data_size  = count * dt_size;
     ucc_rank_t                  rank       = UCC_TL_TEAM_RANK(team);
     ucc_rank_t                  size       = UCC_TL_TEAM_SIZE(team);
-    ucc_ee_executor_task_args_t eargs      = {0};
-    ptrdiff_t      peer_seg_offset, local_seg_offset, offset;
-    ucc_rank_t     peer, step_radix, peer_seg_index, local_seg_index;
-    ucc_status_t   status;
+    ptrdiff_t peer_seg_offset, local_seg_offset, offset;
+    ucc_rank_t peer, step_radix, local_seg_index;
+    ucc_status_t status;
     ucc_kn_radix_t loop_step;
-    size_t         block_count, peer_seg_count, local_seg_count;
-    void          *reduce_data, *local_data;
-    int            is_avg;
+    size_t block_count, peer_seg_count, local_seg_count;
+    void *reduce_data, *local_data;
+    int is_avg;
 
     local_seg_count = 0;
     block_count     = ucc_sra_kn_compute_block_count(count, rank, p);
     UCC_KN_REDUCE_GOTO_PHASE(task->reduce_scatter_kn.phase);
-
     if (KN_NODE_EXTRA == node_type) {
         peer = ucc_knomial_pattern_get_proxy(p, rank);
         UCPCHECK_GOTO(
@@ -73,105 +88,87 @@ UCC_KN_PHASE_EXTRA:
         }
         if (KN_NODE_EXTRA == node_type) {
             goto out;
-        } else {
-            status = ucc_dt_reduce(sbuf, scratch, rbuf, count, dt, args, 0, 0,
-                                   task->reduce_scatter_kn.executor,
-                                   &task->reduce_scatter_kn.etask);
-            if (ucc_unlikely(status != UCC_OK)) {
-                tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
-                task->super.status = status;
-                return;
-            }
-UCC_KN_PHASE_EXTRA_REDUCE:
-            EXEC_TASK_TEST(UCC_KN_PHASE_EXTRA_REDUCE,
-                           "failed to perform dt reduction",
-                           task->reduce_scatter_kn.etask);
         }
+        status = ucc_dt_reduce(sbuf, scratch, rbuf, count, dt, args, 0, 0,
+                               task->reduce_scatter_kn.executor,
+                               &task->reduce_scatter_kn.etask);
+        if (ucc_unlikely(status != UCC_OK)) {
+            tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
+            task->super.status = status;
+            return;
+        }
+UCC_KN_PHASE_EXTRA_REDUCE:
+        EXEC_TASK_TEST(UCC_KN_PHASE_EXTRA_REDUCE,
+                        "failed to perform dt reduction",
+                        task->reduce_scatter_kn.etask);
+
     }
     while (!ucc_knomial_pattern_loop_done(p)) {
-        step_radix  = ucc_kn_compute_step_radix(p);
         block_count = ucc_sra_kn_compute_block_count(count, rank, p);
-        sbuf        = (ucc_knomial_pattern_loop_first_iteration(p))
-                          ? ((KN_NODE_PROXY == node_type || UCC_IS_INPLACE(*args))
-                                 ? args->dst.info.buffer
-                                 : args->src.info.buffer)
-                          : task->reduce_scatter_kn.scratch;
+        get_sbuf_rbuf(p, args, task->reduce_scatter_kn.scratch, block_count,
+                      &sbuf, &rbuf);
+        ucc_kn_rs_pattern_peer_seg(rank, p, &local_seg_count,
+                                   &local_seg_offset);
         for (loop_step = radix - 1; loop_step > 0; loop_step--) {
             peer = ucc_knomial_pattern_get_loop_peer(p, rank, loop_step);
-            if (peer == UCC_KN_PEER_NULL)
+            if (peer == UCC_KN_PEER_NULL) {
                 continue;
-
-            peer_seg_index =
-                ucc_kn_compute_seg_index(peer, p->radix_pow, p);
-            peer_seg_count = ucc_sra_kn_compute_seg_size(
-                block_count, step_radix, peer_seg_index);
-            peer_seg_offset = ucc_sra_kn_compute_seg_offset(
-                block_count, step_radix, peer_seg_index);
+            }
+            ucc_kn_rs_pattern_peer_seg(peer, p, &peer_seg_count,
+                                       &peer_seg_offset);
             UCPCHECK_GOTO(
                 ucc_tl_ucp_send_nb(PTR_OFFSET(sbuf, peer_seg_offset * dt_size),
                                    peer_seg_count * dt_size, mem_type, peer,
                                    team, task),
                 task, out);
-        }
-
-        local_seg_index = ucc_kn_compute_seg_index(rank, p->radix_pow, p);
-        local_seg_count = ucc_sra_kn_compute_seg_size(block_count, step_radix,
-                                                      local_seg_index);
-
-        rbuf = task->reduce_scatter_kn.scratch;
-        if (!ucc_knomial_pattern_loop_first_iteration(p)) {
-            rbuf = PTR_OFFSET(rbuf, block_count * dt_size);
-        }
-        for (loop_step = 1; loop_step < radix; loop_step++) {
-            peer = ucc_knomial_pattern_get_loop_peer(p, rank, loop_step);
-            if (peer == UCC_KN_PEER_NULL)
-                continue;
-            UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(rbuf, local_seg_count * dt_size,
-                                             mem_type, peer, team, task),
-                          task, out);
+            UCPCHECK_GOTO(
+                ucc_tl_ucp_recv_nb(rbuf, local_seg_count * dt_size, mem_type,
+                                   peer, team, task),
+                task, out);
             rbuf = PTR_OFFSET(rbuf, local_seg_count * dt_size);
         }
-    UCC_KN_PHASE_LOOP:
+UCC_KN_PHASE_LOOP:
         if (UCC_INPROGRESS == ucc_tl_ucp_test(task)) {
             SAVE_STATE(UCC_KN_PHASE_LOOP);
             return;
         }
         if (task->tagged.send_posted > p->iteration * (radix - 1)) {
-            sbuf       = (ucc_knomial_pattern_loop_first_iteration(p))
-                             ? ((KN_NODE_PROXY == node_type || UCC_IS_INPLACE(*args))
-                                    ? args->dst.info.buffer
-                                    : args->src.info.buffer)
-                             : task->reduce_scatter_kn.scratch;
-            rbuf       = (!ucc_knomial_pattern_loop_first_iteration(p))
-                             ? PTR_OFFSET(task->reduce_scatter_kn.scratch,
-                                    block_count * dt_size)
-                             : task->reduce_scatter_kn.scratch;
             step_radix = ucc_kn_compute_step_radix(p);
-            local_seg_index =
-                ucc_kn_compute_seg_index(rank, p->radix_pow, p);
-            local_seg_count = ucc_sra_kn_compute_seg_size(
-                block_count, step_radix, local_seg_index);
-            local_seg_offset = ucc_sra_kn_compute_seg_offset(
-                block_count, step_radix, local_seg_index);
+            ucc_kn_rs_pattern_peer_seg(rank, p, &local_seg_count,
+                                       &local_seg_offset);
+            get_sbuf_rbuf(p, args, task->reduce_scatter_kn.scratch, block_count,
+                          &sbuf, &rbuf);
             local_data  = PTR_OFFSET(sbuf, local_seg_offset * dt_size);
             reduce_data = task->reduce_scatter_kn.scratch;
             is_avg      = args->op == UCC_OP_AVG &&
                      (avg_pre_op ? ucc_knomial_pattern_loop_first_iteration(p)
                                  : ucc_knomial_pattern_loop_last_iteration(p));
+            ucc_assert((step_radix - 1) ==
+                       (task->tagged.send_posted - p->iteration * (radix - 1)));
 
-            if (task->reduce_scatter_kn.scratch_mc_header &&
+            if (!task->reduce_scatter_kn.scratch_mc_header &&
                 ucc_knomial_pattern_loop_last_iteration(p)) {
-                ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size, radix,
-                                                 &offset, &local_seg_count);
-                reduce_data = PTR_OFFSET(args->dst.info.buffer, offset);
+                status = ucc_dt_reduce_strided(
+                    rbuf, PTR_OFFSET(rbuf, local_seg_count * dt_size), rbuf,
+                    step_radix - 2, local_seg_count, local_seg_count * dt_size,
+                    dt, args, 0, 0, task->reduce_scatter_kn.executor,
+                    &task->reduce_scatter_kn.etask);
+
+            } else {
+                if (task->reduce_scatter_kn.scratch_mc_header &&
+                    ucc_knomial_pattern_loop_last_iteration(p)) {
+                    ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size,
+                                                     radix, &offset,
+                                                     &local_seg_count);
+                    reduce_data = PTR_OFFSET(args->dst.info.buffer, offset);
+                }
+                status = ucc_dt_reduce_strided(
+                    local_data, rbuf, reduce_data, step_radix - 1,
+                    local_seg_count, local_seg_count * dt_size, dt, args,
+                    is_avg ? UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA : 0,
+                    AVG_ALPHA(task), task->reduce_scatter_kn.executor,
+                    &task->reduce_scatter_kn.etask);
             }
-            status = ucc_dt_reduce_strided(
-                local_data, rbuf, reduce_data,
-                task->tagged.send_posted - p->iteration * (radix - 1),
-                local_seg_count, local_seg_count * dt_size, dt, args,
-                is_avg ? UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA : 0,
-                AVG_ALPHA(task), task->reduce_scatter_kn.executor,
-                &task->reduce_scatter_kn.etask);
             if (ucc_unlikely(UCC_OK != status)) {
                 tl_error(UCC_TASK_LIB(task), "failed to perform dt reduction");
                 task->super.status = status;
@@ -182,25 +179,42 @@ UCC_KN_PHASE_REDUCE:
                            "failed to perform dt reduction",
                            task->reduce_scatter_kn.etask);
         }
-        ucc_knomial_pattern_next_iteration(p);
+        ucc_kn_rs_pattern_next_iter(p);
     }
 
     if (!task->reduce_scatter_kn.scratch_mc_header) {
+        ucc_knomial_pattern_prev_iteration(p);
+        get_sbuf_rbuf(p, args, task->reduce_scatter_kn.scratch, block_count,
+                      &sbuf, &rbuf);
+
+        step_radix = ucc_kn_compute_step_radix(p);
+        local_seg_index = ucc_kn_compute_seg_index(
+            rank, p->radix_pow, p);
+        local_seg_count = ucc_sra_kn_compute_seg_size(
+            block_count, step_radix, local_seg_index);
+        local_seg_offset = ucc_sra_kn_compute_seg_offset(
+            block_count, step_radix, local_seg_index);
+        local_data  = PTR_OFFSET(sbuf, local_seg_offset * dt_size);
+        is_avg      = args->op == UCC_OP_AVG &&
+                            (avg_pre_op ? ucc_knomial_pattern_loop_first_iteration(p)
+                                        : ucc_knomial_pattern_loop_last_iteration(p));
+
         ucc_sra_kn_get_offset_and_seglen(count, dt_size, rank, size, radix,
                                          &offset, &local_seg_count);
-        eargs.task_type = UCC_EE_EXECUTOR_TASK_COPY;
-        eargs.copy.dst  = PTR_OFFSET(args->dst.info.buffer, offset);
-        eargs.copy.src  = task->reduce_scatter_kn.scratch;
-        eargs.copy.len  = local_seg_count * dt_size;
-        status = ucc_ee_executor_task_post(task->reduce_scatter_kn.executor, &eargs,
-                                           &task->reduce_scatter_kn.etask);
+        status = ucc_dt_reduce(local_data, rbuf,
+                               PTR_OFFSET(args->dst.info.buffer, offset),
+                               local_seg_count, dt, args,
+                               is_avg ? UCC_EEE_TASK_FLAG_REDUCE_WITH_ALPHA : 0,
+                               AVG_ALPHA(task),
+                               task->reduce_scatter_kn.executor,
+                               &task->reduce_scatter_kn.etask);
         if (ucc_unlikely(status != UCC_OK)) {
-            tl_error(UCC_TASK_LIB(task), "failed to copy data to dst buffer");
+            tl_error(UCC_TASK_LIB(task), "failed to reduce data to dst buffer");
             task->super.status = status;
             return;
         }
     UCC_KN_PHASE_COMPLETE:
-        EXEC_TASK_TEST(UCC_KN_PHASE_COMPLETE, "failed to perform memcpy",
+        EXEC_TASK_TEST(UCC_KN_PHASE_COMPLETE, "failed to perform reduce",
                        task->reduce_scatter_kn.etask);
     }
 UCC_KN_PHASE_PROXY: /* unused label */
@@ -222,13 +236,14 @@ ucc_status_t ucc_tl_ucp_reduce_scatter_knomial_start(ucc_coll_task_t *coll_task)
     UCC_TL_UCP_PROFILE_REQUEST_EVENT(coll_task, "ucp_reduce_scatter_kn_start",
                                      0);
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
-    ucc_knomial_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
-                             &task->reduce_scatter_kn.p);
+    ucc_kn_rsx_pattern_init(size, rank, task->reduce_scatter_kn.p.radix,
+                            args->dst.info.count, &task->reduce_scatter_kn.p);
     if (!task->reduce_scatter_kn.scratch_mc_header) {
         task->reduce_scatter_kn.scratch = args->dst.info.buffer;
     }
     task->reduce_scatter_kn.phase = UCC_KN_PHASE_INIT;
-    status                        = ucc_coll_task_get_executor(&task->super,
+
+    status = ucc_coll_task_get_executor(&task->super,
                                         &task->reduce_scatter_kn.executor);
     if (ucc_unlikely(status != UCC_OK)) {
         return status;

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_knomial.c
@@ -17,33 +17,35 @@
 
 void ucc_tl_ucp_reduce_scatter_knomial_progress(ucc_coll_task_t *coll_task)
 {
-    ucc_tl_ucp_task_t     *task  = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t       *args  = &TASK_ARGS(task);
-    ucc_tl_ucp_team_t     *team  = TASK_TEAM(task);
-    ucc_kn_radix_t         radix = task->reduce_scatter_kn.p.radix;
-    int                    avg_pre_op =
+    ucc_tl_ucp_task_t          *task       = ucc_derived_of(coll_task,
+                                                            ucc_tl_ucp_task_t);
+    ucc_coll_args_t            *args       = &TASK_ARGS(task);
+    ucc_tl_ucp_team_t          *team       = TASK_TEAM(task);
+    ucc_kn_radix_t              radix      = task->reduce_scatter_kn.p.radix;
+    int                         avg_pre_op =
         UCC_TL_UCP_TEAM_LIB(team)->cfg.reduce_avg_pre_op;
-    uint8_t                node_type  = task->reduce_scatter_kn.p.node_type;
-    ucc_knomial_pattern_t *p          = &task->reduce_scatter_kn.p;
-    void                  *scratch    = task->reduce_scatter_kn.scratch;
-    void                  *rbuf       = args->dst.info.buffer;
-    ucc_memory_type_t      mem_type   = args->dst.info.mem_type;
-    size_t                 count      = args->dst.info.count;
-    ucc_datatype_t         dt         = args->dst.info.datatype;
-    void                  *sbuf       = UCC_IS_INPLACE(*args) ?
+    uint8_t                     node_type  =
+        task->reduce_scatter_kn.p.node_type;
+    ucc_knomial_pattern_t      *p          = &task->reduce_scatter_kn.p;
+    void                       *scratch    = task->reduce_scatter_kn.scratch;
+    void                       *rbuf       = args->dst.info.buffer;
+    ucc_memory_type_t           mem_type   = args->dst.info.mem_type;
+    size_t                      count      = args->dst.info.count;
+    ucc_datatype_t              dt         = args->dst.info.datatype;
+    void                       *sbuf       = UCC_IS_INPLACE(*args) ?
         rbuf : args->src.info.buffer;
-    size_t                 dt_size    = ucc_dt_size(dt);
-    size_t                 data_size  = count * dt_size;
-    ucc_rank_t             rank       = UCC_TL_TEAM_RANK(team);
-    ucc_rank_t             size       = UCC_TL_TEAM_SIZE(team);
-    ptrdiff_t              peer_seg_offset, local_seg_offset, offset;
-    ucc_rank_t             peer, step_radix, peer_seg_index, local_seg_index;
-    ucc_status_t           status;
-    ucc_kn_radix_t         loop_step;
-    size_t                 block_count, peer_seg_count, local_seg_count;
-    void                  *reduce_data, *local_data;
-    int                    is_avg;
-    ucc_ee_executor_task_args_t eargs;
+    size_t                      dt_size    = ucc_dt_size(dt);
+    size_t                      data_size  = count * dt_size;
+    ucc_rank_t                  rank       = UCC_TL_TEAM_RANK(team);
+    ucc_rank_t                  size       = UCC_TL_TEAM_SIZE(team);
+    ucc_ee_executor_task_args_t eargs      = {0};
+    ptrdiff_t      peer_seg_offset, local_seg_offset, offset;
+    ucc_rank_t     peer, step_radix, peer_seg_index, local_seg_index;
+    ucc_status_t   status;
+    ucc_kn_radix_t loop_step;
+    size_t         block_count, peer_seg_count, local_seg_count;
+    void          *reduce_data, *local_data;
+    int            is_avg;
 
     local_seg_count = 0;
     block_count     = ucc_sra_kn_compute_block_count(count, rank, p);

--- a/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
+++ b/src/components/tl/ucp/reduce_scatter/reduce_scatter_ring.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -11,6 +11,8 @@
 #include "utils/ucc_math.h"
 #include "utils/ucc_coll_utils.h"
 #include "utils/ucc_dt_reduce.h"
+
+#define REVERSED_FRAG 1
 
 static inline void send_completion_common(void *request, ucs_status_t status,
                                           void *user_data)
@@ -112,7 +114,10 @@ static void ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
 
     sendto   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
     recvfrom = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
-
+    if (team->cfg.use_reordering) {
+        sendto   = ucc_ep_map_eval(task->subset.map, sendto);
+        recvfrom = ucc_ep_map_eval(task->subset.map, recvfrom);
+    }
     max_block_size = task->reduce_scatter_ring.max_block_count * dt_size;
     busy           = task->reduce_scatter_ring.s_scratch_busy;
     r_scratch      = task->reduce_scatter_ring.scratch;
@@ -129,8 +134,11 @@ static void ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
         reduce_target = s_scratch[id];
         step          = task->tagged.send_posted;
         prevblock     = (rank - 1 - step + size) % size;
-        prevblock =
+        prevblock     =
             ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, prevblock);
+        if (team->cfg.use_reordering) {
+            prevblock = ucc_ep_map_eval(task->subset.map, prevblock);
+        }
         /* reduction */
         ucc_assert(task->tagged.recv_posted == task->tagged.recv_completed);
         ucc_assert(task->tagged.recv_posted < size);
@@ -172,7 +180,9 @@ static void ucc_tl_ucp_reduce_scatter_ring_progress(ucc_coll_task_t *coll_task)
         recv_data_from = (rank - 2 - step + size) % size;
         recv_data_from =
             ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recv_data_from);
-
+        if (team->cfg.use_reordering) {
+            recv_data_from = ucc_ep_map_eval(task->subset.map, recv_data_from);
+        }
         ucc_ring_frag_count(task, count, recv_data_from, &frag_count);
 
         UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(r_scratch, frag_count * dt_size, mem_type,
@@ -199,17 +209,18 @@ ucc_tl_ucp_reduce_scatter_ring_start(ucc_coll_task_t *coll_task)
     ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
     ucc_rank_t         size     = task->subset.map.ep_num;
     ucc_rank_t         rank     = task->subset.myrank;
-    ucc_rank_t         sendto   = (rank + 1) % size;
-    ucc_rank_t         recvfrom = (rank - 1 + size) % size;
     size_t             count    = args->dst.info.count * size;
     ucc_datatype_t     dt       = args->dst.info.datatype;
     size_t             dt_size  = ucc_dt_size(dt);
     ucc_memory_type_t  mem_type = args->dst.info.mem_type;
     void *             sbuf     = args->src.info.buffer;
     int                step     = 0;
+    ucc_rank_t         sendto   = (rank + 1) % size;
+    ucc_rank_t         recvfrom = (rank - 1 + size) % size;
+    ucc_rank_t         recv_block = (rank - 2 - step + size) % size;
+    ucc_rank_t         send_block = (rank - 1 - step + size) % size;
     size_t             block_offset, frag_count, frag_offset;
     void              *r_scratch;
-    ucc_rank_t         send_block, recv_block;
     ucc_status_t       status;
 
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
@@ -223,13 +234,17 @@ ucc_tl_ucp_reduce_scatter_ring_start(ucc_coll_task_t *coll_task)
         return status;
     }
 
+    r_scratch  = task->reduce_scatter_ring.scratch;
     sendto     = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, sendto);
     recvfrom   = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recvfrom);
-    r_scratch  = task->reduce_scatter_ring.scratch;
-    recv_block = (rank - 2 - step + size) % size;
-    send_block = (rank - 1 - step + size) % size;
     recv_block = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, recv_block);
     send_block = ucc_ep_map_eval(task->reduce_scatter_ring.inv_map, send_block);
+    if (team->cfg.use_reordering) {
+        sendto     = ucc_ep_map_eval(task->subset.map, sendto);
+        recvfrom   = ucc_ep_map_eval(task->subset.map, recvfrom);
+        recv_block = ucc_ep_map_eval(task->subset.map, recv_block);
+        send_block = ucc_ep_map_eval(task->subset.map, send_block);
+    }
 
     ucc_ring_frag_count(task, count, recv_block, &frag_count);
     UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(r_scratch, frag_count * dt_size, mem_type,
@@ -253,8 +268,7 @@ static ucc_status_t
 ucc_tl_ucp_reduce_scatter_ring_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-
-    if (task->reduce_scatter_ring.inv_map.type != UCC_EP_MAP_FULL) {
+    if (task->reduce_scatter_ring.frag == REVERSED_FRAG) {
         ucc_ep_map_destroy(&task->reduce_scatter_ring.inv_map);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
@@ -262,21 +276,27 @@ ucc_tl_ucp_reduce_scatter_ring_finalize(ucc_coll_task_t *coll_task)
 
 static ucc_status_t ucc_tl_ucp_reduce_scatter_ring_init_subset(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
-    ucc_coll_task_t **task_h, ucc_subset_t subset, int n_frags, int frag,
+    ucc_coll_task_t **task_h, ucc_subset_t *subsets, int n_frags, int frag,
     void *scratch, size_t max_block_count)
 {
     ucc_tl_ucp_task_t *task;
+    ucc_tl_ucp_team_t *tl_team;
     ucc_status_t       status;
 
     task                 = ucc_tl_ucp_init_task(coll_args, team);
+    tl_team              = TASK_TEAM(task);
     task->super.post     = ucc_tl_ucp_reduce_scatter_ring_start;
     task->super.progress = ucc_tl_ucp_reduce_scatter_ring_progress;
     task->super.finalize = ucc_tl_ucp_reduce_scatter_ring_finalize;
-    task->subset         = subset;
-
-    if (task->subset.map.type != UCC_EP_MAP_FULL) {
-        status = ucc_ep_map_create_inverse(task->subset.map,
-                                           &task->reduce_scatter_ring.inv_map);
+    task->subset.map     = subsets[frag].map;
+    task->subset.myrank  = subsets[frag].myrank;
+    if (frag == REVERSED_FRAG) {
+        if (tl_team->cfg.use_reordering) {
+            task->subset.map = subsets[0].map;
+        }
+        status = ucc_ep_map_create_inverse(subsets[frag].map,
+                                           &task->reduce_scatter_ring.inv_map,
+                                           frag && tl_team->cfg.use_reordering);
         if (UCC_OK != status) {
             return status;
         }
@@ -330,6 +350,7 @@ ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
     ucc_tl_ucp_schedule_t *tl_schedule;
     ucc_schedule_t        *schedule;
     ucc_coll_task_t       *ctask;
+    ucc_sbgp_t            *sbgp;
     ucc_status_t           status;
     ucc_subset_t           s[2];
     int                    i, n_subsets;
@@ -348,21 +369,24 @@ ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-    schedule     = &tl_schedule->super.super;
+    schedule  = &tl_schedule->super.super;
     /* if count == size then we have 1 elem per rank, not enough
        to split into 2 sets */
-    n_subsets    = (bidir && (count > size)) ? 2 : 1;
+    n_subsets = (bidir && (count > size)) ? 2 : 1;
 
-    s[0].myrank     = UCC_TL_TEAM_RANK(tl_team);
-    s[0].map.type   = UCC_EP_MAP_FULL;
-    s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
-
-    s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
-    s[1].myrank = ucc_ep_map_eval(s[1].map, UCC_TL_TEAM_RANK(tl_team));
-
-
-    count_per_set    = (count + n_subsets - 1) / n_subsets;
-    max_segcount     = ucc_buffer_block_count(count_per_set, size, 0);
+    if (tl_team->cfg.use_reordering) {
+        sbgp = ucc_topo_get_sbgp(tl_team->topo, UCC_SBGP_FULL_HOST_ORDERED);
+        s[0].myrank = sbgp->group_rank;
+        s[0].map    = sbgp->map;
+    } else {
+        s[0].myrank     = UCC_TL_TEAM_RANK(tl_team);
+        s[0].map.type   = UCC_EP_MAP_FULL;
+        s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
+    }
+    s[1].map      = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
+    s[1].myrank   = ucc_ep_map_eval(s[1].map, s[0].myrank);
+    count_per_set = (count + n_subsets - 1) / n_subsets;
+    max_segcount  = ucc_buffer_block_count(count_per_set, size, 0);
     /* in flight we can have 2 sends from 2 differnt blocks and 1 recv:
        need 3 * max_segcount of scratch per set */
     to_alloc_per_set = max_segcount * 3;
@@ -370,10 +394,9 @@ ucc_tl_ucp_reduce_scatter_ring_init(ucc_base_coll_args_t *coll_args,
                                 to_alloc_per_set * dt_size * n_subsets,
                                 mem_type),
                    out, status);
-
     for (i = 0; i < n_subsets; i++) {
         UCC_CHECK_GOTO(ucc_tl_ucp_reduce_scatter_ring_init_subset(
-                           coll_args, team, &ctask, s[i], n_subsets, i,
+                           coll_args, team, &ctask, s, n_subsets, i,
                            PTR_OFFSET(tl_schedule->scratch_mc_header->addr,
                                       to_alloc_per_set * i * dt_size),
                            max_segcount),

--- a/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
+++ b/src/components/tl/ucp/reduce_scatterv/reduce_scatterv_ring.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * See file LICENSE for terms.
  */
@@ -11,6 +11,8 @@
 #include "utils/ucc_math.h"
 #include "utils/ucc_coll_utils.h"
 #include "utils/ucc_dt_reduce.h"
+
+#define REVERSED_FRAG 1
 
 static inline void send_completion_common(void *request, ucs_status_t status,
                                           void *user_data)
@@ -117,7 +119,10 @@ static void ucc_tl_ucp_reduce_scatterv_ring_progress(ucc_coll_task_t *coll_task)
 
     sendto   = ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, sendto);
     recvfrom = ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, recvfrom);
-
+    if (team->cfg.use_reordering) {
+        sendto   = ucc_ep_map_eval(task->subset.map, sendto);
+        recvfrom = ucc_ep_map_eval(task->subset.map, recvfrom);
+    }
     max_block_size = task->reduce_scatterv_ring.max_block_count * dt_size;
     busy           = task->reduce_scatterv_ring.s_scratch_busy;
     r_scratch      = task->reduce_scatterv_ring.scratch;
@@ -134,12 +139,14 @@ static void ucc_tl_ucp_reduce_scatterv_ring_progress(ucc_coll_task_t *coll_task)
         reduce_target = s_scratch[id];
         step          = task->tagged.send_posted;
         prevblock     = (rank - 1 - step + size) % size;
-        prevblock =
+        prevblock     =
             ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, prevblock);
         /* reduction */
         ucc_assert(task->tagged.recv_posted == task->tagged.recv_completed);
         ucc_assert(task->tagged.recv_posted < size);
-
+        if (team->cfg.use_reordering) {
+            prevblock = ucc_ep_map_eval(task->subset.map, prevblock);
+        }
         ucc_ring_frag_count(task, prevblock, &frag_count);
         ucc_ring_frag_block_offset(task, prevblock, &block_offset,
                                    &frag_offset);
@@ -177,7 +184,9 @@ static void ucc_tl_ucp_reduce_scatterv_ring_progress(ucc_coll_task_t *coll_task)
         recv_data_from = (rank - 2 - step + size) % size;
         recv_data_from =
             ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, recv_data_from);
-
+        if (team->cfg.use_reordering) {
+            recv_data_from = ucc_ep_map_eval(task->subset.map, recv_data_from);
+        }
         ucc_ring_frag_count(task, recv_data_from, &frag_count);
 
         UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(r_scratch, frag_count * dt_size,
@@ -200,20 +209,21 @@ static ucc_status_t
 ucc_tl_ucp_reduce_scatterv_ring_start(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task     = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
-    ucc_coll_args_t *  args     = &TASK_ARGS(task);
+    ucc_coll_args_t   *args     = &TASK_ARGS(task);
     ucc_tl_ucp_team_t *team     = TASK_TEAM(task);
     ucc_rank_t         size     = task->subset.map.ep_num;
     ucc_rank_t         rank     = task->subset.myrank;
-    ucc_rank_t         sendto   = (rank + 1) % size;
-    ucc_rank_t         recvfrom = (rank - 1 + size) % size;
     ucc_datatype_t     dt       = args->dst.info_v.datatype;
     size_t             dt_size  = ucc_dt_size(dt);
     ucc_memory_type_t  mem_type = args->dst.info_v.mem_type;
-    void *             sbuf     = args->src.info.buffer;
+    void              *sbuf     = args->src.info.buffer;
     int                step     = 0;
+    ucc_rank_t         sendto   = (rank + 1) % size;
+    ucc_rank_t         recvfrom = (rank - 1 + size) % size;
+    ucc_rank_t         recv_block = (rank - 2 - step + size) % size;
+    ucc_rank_t         send_block = (rank - 1 - step + size) % size;
     size_t             block_offset, frag_count, frag_offset;
-    void *             r_scratch;
-    ucc_rank_t         send_block, recv_block;
+    void              *r_scratch;
     ucc_status_t       status;
 
     ucc_tl_ucp_task_reset(task, UCC_INPROGRESS);
@@ -221,20 +231,24 @@ ucc_tl_ucp_reduce_scatterv_ring_start(ucc_coll_task_t *coll_task)
         sbuf = args->dst.info_v.buffer;
     }
     status = ucc_coll_task_get_executor(&task->super,
-                                        &task->reduce_scatter_ring.executor);
+                                        &task->reduce_scatterv_ring.executor);
     if (ucc_unlikely(status != UCC_OK)) {
         return status;
     }
 
+    r_scratch  = task->reduce_scatterv_ring.scratch;
     sendto     = ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, sendto);
     recvfrom   = ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, recvfrom);
-    r_scratch  = task->reduce_scatterv_ring.scratch;
-    recv_block = (rank - 2 - step + size) % size;
-    send_block = (rank - 1 - step + size) % size;
     recv_block =
         ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, recv_block);
     send_block =
         ucc_ep_map_eval(task->reduce_scatterv_ring.inv_map, send_block);
+    if (team->cfg.use_reordering) {
+        sendto     = ucc_ep_map_eval(task->subset.map, sendto);
+        recvfrom   = ucc_ep_map_eval(task->subset.map, recvfrom);
+        recv_block = ucc_ep_map_eval(task->subset.map, recv_block);
+        send_block = ucc_ep_map_eval(task->subset.map, send_block);
+    }
 
     ucc_ring_frag_count(task, recv_block, &frag_count);
     UCPCHECK_GOTO(ucc_tl_ucp_recv_nb(r_scratch, frag_count * dt_size, mem_type,
@@ -258,7 +272,7 @@ ucc_tl_ucp_reduce_scatterv_ring_finalize(ucc_coll_task_t *coll_task)
 {
     ucc_tl_ucp_task_t *task = ucc_derived_of(coll_task, ucc_tl_ucp_task_t);
 
-    if (task->reduce_scatterv_ring.inv_map.type != UCC_EP_MAP_FULL) {
+    if (task->reduce_scatterv_ring.frag == REVERSED_FRAG) {
         ucc_ep_map_destroy(&task->reduce_scatterv_ring.inv_map);
     }
     return ucc_tl_ucp_coll_finalize(coll_task);
@@ -266,21 +280,27 @@ ucc_tl_ucp_reduce_scatterv_ring_finalize(ucc_coll_task_t *coll_task)
 
 static ucc_status_t ucc_tl_ucp_reduce_scatterv_ring_init_subset(
     ucc_base_coll_args_t *coll_args, ucc_base_team_t *team,
-    ucc_coll_task_t **task_h, ucc_subset_t subset, int n_frags, int frag,
+    ucc_coll_task_t **task_h, ucc_subset_t *subsets, int n_frags, int frag,
     void *scratch, size_t max_block_count)
 {
     ucc_tl_ucp_task_t *task;
+    ucc_tl_ucp_team_t *tl_team;
     ucc_status_t       status;
 
     task                 = ucc_tl_ucp_init_task(coll_args, team);
+    tl_team              = TASK_TEAM(task);
     task->super.post     = ucc_tl_ucp_reduce_scatterv_ring_start;
     task->super.progress = ucc_tl_ucp_reduce_scatterv_ring_progress;
     task->super.finalize = ucc_tl_ucp_reduce_scatterv_ring_finalize;
-    task->subset         = subset;
-
-    if (task->subset.map.type != UCC_EP_MAP_FULL) {
-        status = ucc_ep_map_create_inverse(task->subset.map,
-                                           &task->reduce_scatterv_ring.inv_map);
+    task->subset.map     = subsets[frag].map;
+    task->subset.myrank  = subsets[frag].myrank;
+    if (frag == REVERSED_FRAG) {
+        if (tl_team->cfg.use_reordering) {
+            task->subset.map = subsets[0].map;
+        }
+        status = ucc_ep_map_create_inverse(subsets[frag].map,
+                                           &task->reduce_scatterv_ring.inv_map,
+                                           frag && tl_team->cfg.use_reordering);
         if (UCC_OK != status) {
             return status;
         }
@@ -335,12 +355,13 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
     ucc_datatype_t     dt       = coll_args->args.dst.info_v.datatype;
     size_t             dt_size  = ucc_dt_size(dt);
     ucc_memory_type_t  mem_type = coll_args->args.dst.info_v.mem_type;
-    int                bidir =
+    int                bidir    =
         UCC_TL_UCP_TEAM_LIB(tl_team)->cfg.reduce_scatterv_ring_bidirectional;
     size_t                 to_alloc_per_set, max_segcount, count_per_set, count;
     ucc_tl_ucp_schedule_t *tl_schedule;
-    ucc_schedule_t *       schedule;
-    ucc_coll_task_t *      ctask;
+    ucc_schedule_t        *schedule;
+    ucc_coll_task_t       *ctask;
+    ucc_sbgp_t            *sbgp;
     ucc_status_t           status;
     ucc_subset_t           s[2];
     int                    i, n_subsets;
@@ -362,17 +383,22 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
         return status;
     }
 
-    schedule    = &tl_schedule->super.super;
+    schedule  = &tl_schedule->super.super;
     /* if count == size then we have 1 elem per rank, not enough
        to split into 2 sets */
     n_subsets = (bidir && (count > size)) ? 2 : 1;
 
-    s[0].myrank     = UCC_TL_TEAM_RANK(tl_team);
-    s[0].map.type   = UCC_EP_MAP_FULL;
-    s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
-
+    if (tl_team->cfg.use_reordering) {
+        sbgp = ucc_topo_get_sbgp(tl_team->topo, UCC_SBGP_FULL_HOST_ORDERED);
+        s[0].myrank = sbgp->group_rank;
+        s[0].map    = sbgp->map;
+    } else {
+        s[0].myrank     = UCC_TL_TEAM_RANK(tl_team);
+        s[0].map.type   = UCC_EP_MAP_FULL;
+        s[0].map.ep_num = UCC_TL_TEAM_SIZE(tl_team);
+    }
     s[1].map    = ucc_ep_map_create_reverse(UCC_TL_TEAM_SIZE(tl_team));
-    s[1].myrank = ucc_ep_map_eval(s[1].map, UCC_TL_TEAM_RANK(tl_team));
+    s[1].myrank = ucc_ep_map_eval(s[1].map, s[0].myrank);
 
     if (coll_args->mask & UCC_BASE_CARGS_MAX_FRAG_COUNT) {
         max_segcount = coll_args->max_frag_count;
@@ -392,7 +418,7 @@ ucc_tl_ucp_reduce_scatterv_ring_init(ucc_base_coll_args_t *coll_args,
 
     for (i = 0; i < n_subsets; i++) {
         UCC_CHECK_GOTO(ucc_tl_ucp_reduce_scatterv_ring_init_subset(
-                           coll_args, team, &ctask, s[i], n_subsets, i,
+                           coll_args, team, &ctask, s, n_subsets, i,
                            PTR_OFFSET(tl_schedule->scratch_mc_header->addr,
                                       to_alloc_per_set * i * dt_size),
                            count_per_set),

--- a/src/components/tl/ucp/tl_ucp_coll.c
+++ b/src/components/tl/ucp/tl_ucp_coll.c
@@ -27,8 +27,8 @@
 const ucc_tl_ucp_default_alg_desc_t
     ucc_tl_ucp_default_alg_descs[UCC_TL_UCP_N_DEFAULT_ALG_SELECT_STR] = {
         {
-            .select_str = UCC_TL_UCP_ALLGATHER_DEFAULT_ALG_SELECT_STR,
-            .str_get_fn = NULL
+            .select_str = NULL,
+            .str_get_fn = ucc_tl_ucp_allgather_score_str_get
         },
         {
             .select_str = NULL,
@@ -251,6 +251,9 @@ ucc_status_t ucc_tl_ucp_alg_id_to_init(int alg_id, const char *alg_id_str,
             break;
         case UCC_TL_UCP_ALLGATHER_ALG_RING:
             *init = ucc_tl_ucp_allgather_ring_init;
+            break;
+        case UCC_TL_UCP_ALLGATHER_ALG_NEIGHBOR:
+            *init = ucc_tl_ucp_allgather_neighbor_init;
             break;
         default:
             status = UCC_ERR_INVALID_PARAM;

--- a/src/core/ucc_coll.c
+++ b/src/core/ucc_coll.c
@@ -216,6 +216,7 @@ UCC_CORE_PROFILE_FUNC(ucc_status_t, ucc_collective_init,
         coll_mem_type = ucc_coll_args_mem_type(coll_args, team->rank);
         switch(coll_mem_type) {
         case UCC_MEMORY_TYPE_CUDA:
+        case UCC_MEMORY_TYPE_CUDA_MANAGED:
             coll_ee_type = UCC_EE_CUDA_STREAM;
             break;
         case UCC_MEMORY_TYPE_ROCM:

--- a/src/utils/arch/cpu.h
+++ b/src/utils/arch/cpu.h
@@ -2,6 +2,7 @@
 * Copyright (c) NVIDIA CORPORATION & AFFILIATES, 2001-2023. ALL RIGHTS RESERVED.
 * Copyright (C) ARM Ltd. 2016.  ALL RIGHTS RESERVED.
 * Copyright (C) Shanghai Zhaoxin Semiconductor Co., Ltd. 2020. ALL RIGHTS RESERVED.
+* Copyright (C) Rivos Inc. 2023
 *
 * See file LICENSE for terms.
 */
@@ -44,6 +45,7 @@ typedef enum ucc_cpu_vendor {
     UCC_CPU_VENDOR_AMD,
     UCC_CPU_VENDOR_GENERIC_ARM,
     UCC_CPU_VENDOR_GENERIC_PPC,
+    UCC_CPU_VENDOR_GENERIC_RISCV,
     UCC_CPU_VENDOR_FUJITSU_ARM,
     UCC_CPU_VENDOR_ZHAOXIN,
     UCC_CPU_VENDOR_LAST
@@ -59,6 +61,8 @@ static inline ucc_cpu_vendor_t ucc_get_vendor_from_str(const char *v_name)
         return UCC_CPU_VENDOR_GENERIC_ARM;
     if (strcasecmp(v_name, "ppc") == 0)
         return UCC_CPU_VENDOR_GENERIC_PPC;
+    if (strcasecmp(v_name, "riscv") == 0)
+        return UCC_CPU_VENDOR_GENERIC_RISCV;
     if (strcasecmp(v_name, "fujitsu") == 0)
         return UCC_CPU_VENDOR_FUJITSU_ARM;
     if (strcasecmp(v_name, "zhaoxin") == 0)
@@ -107,6 +111,8 @@ static inline ucc_cpu_model_t ucc_get_model_from_str(const char *m_name)
 #  include "ppc64/cpu.h"
 #elif defined(__aarch64__)
 #  include "aarch64/cpu.h"
+#elif defined(__riscv) && (__riscv_xlen == 64)
+#  include "riscv64/cpu.h"
 #else
 #  error "Unsupported architecture"
 #endif

--- a/src/utils/arch/riscv64/cpu.h
+++ b/src/utils/arch/riscv64/cpu.h
@@ -1,0 +1,33 @@
+/**
+* Copyright (c) 2001-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+* Copyright (C) ARM Ltd. 2016-2017.  ALL RIGHTS RESERVED.
+* Copyright (C) Rivos Inc. 2023
+*
+* See file LICENSE for terms.
+*/
+
+#ifndef UCC_UTILS_ARCH_RISCV64_CPU_H_
+#define UCC_UTILS_ARCH_RISCV64_CPU_H_
+
+#define UCC_ARCH_CACHE_LINE_SIZE 64
+
+/* RVWMO rules */
+#define ucc_memory_bus_fence()       asm volatile("fence iorw, iorw" ::: "memory")
+#define ucc_memory_bus_store_fence() asm volatile("fence ow, ow" ::: "memory")
+#define ucc_memory_bus_load_fence()  asm volatile("fence ir, ir" ::: "memory")
+
+#define ucc_memory_cpu_fence()       asm volatile("fence rw, rw" ::: "memory")
+#define ucc_memory_cpu_store_fence() asm volatile("fence rw, w" ::: "memory")
+#define ucc_memory_cpu_load_fence()  asm volatile("fence r, rw" ::: "memory")
+
+static inline ucc_cpu_model_t ucc_arch_get_cpu_model()
+{
+    return UCC_CPU_MODEL_UNKNOWN;
+}
+
+static inline ucc_cpu_vendor_t ucc_arch_get_cpu_vendor()
+{
+    return UCC_CPU_VENDOR_GENERIC_RISCV;
+}
+
+#endif

--- a/src/utils/ucc_coll_utils.c
+++ b/src/utils/ucc_coll_utils.c
@@ -631,20 +631,22 @@ ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size)
     return map;
 }
 
-static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map)
+static inline int ucc_ep_map_is_reverse(ucc_ep_map_t *map,
+                                        int reversed_reordered_flag)
 {
-    return (map->type == UCC_EP_MAP_STRIDED) &&
+    return (((map->type == UCC_EP_MAP_STRIDED) &&
            (map->strided.start == map->ep_num - 1) &&
-           (map->strided.stride == -1);
+           (map->strided.stride == -1)) || reversed_reordered_flag);
 }
 
-ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map)
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
+                                       int reversed_reordered_flag)
 {
     ucc_ep_map_t inv;
     ucc_rank_t   i, r;
     ucc_rank_t   max_rank;
 
-    if (ucc_ep_map_is_reverse(&map)) {
+    if (ucc_ep_map_is_reverse(&map, reversed_reordered_flag)) {
         inv = map;
     } else {
         inv.type            = UCC_EP_MAP_ARRAY;

--- a/src/utils/ucc_coll_utils.h
+++ b/src/utils/ucc_coll_utils.h
@@ -229,8 +229,16 @@ void ucc_coll_str(const ucc_coll_task_t *task, char *str, size_t len,
    rank r -> size - 1 - r */
 ucc_ep_map_t ucc_ep_map_create_reverse(ucc_rank_t size);
 
-/* Creates an inverse mapping for a given map */
-ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map);
+/* Creates an inverse mapping for a given map,
+   only if given map is not a reverse map
+   or a reordered map within the reverse direction task.
+   @param [in] map                       given map
+   @param [in] inv_map                   output map
+   @param [in] reversed_reordered_flag   1 if is reverse direction task and
+                                         reorder ranks is configured as yes,
+                                         0 otherwise. */
+ucc_status_t ucc_ep_map_create_inverse(ucc_ep_map_t map, ucc_ep_map_t *inv_map,
+                                       int reversed_reordered_flag);
 
 ucc_status_t ucc_ep_map_create_nested(ucc_ep_map_t *base_map,
                                       ucc_ep_map_t *sub_map,

--- a/src/utils/ucc_dt_reduce.h
+++ b/src/utils/ucc_dt_reduce.h
@@ -33,7 +33,7 @@ ucc_dt_reduce_strided(void *src1, void *src2, void *dst, size_t n_vectors,
 {
     ucc_ee_executor_task_args_t eargs;
 
-    if (count == 0) {
+    if (count == 0 || n_vectors == 0) {
         *task = NULL;
         return UCC_OK;
     }

--- a/test/gtest/coll/test_allgather.cc
+++ b/test/gtest/coll/test_allgather.cc
@@ -296,7 +296,7 @@ INSTANTIATE_TEST_CASE_P(
 #endif
         ::testing::Values(1,3,8192), // count
         ::testing::Values(TEST_INPLACE, TEST_NO_INPLACE),
-        ::testing::Values("knomial", "ring")),
+        ::testing::Values("knomial", "ring", "neighbor")),
         [](const testing::TestParamInfo<test_allgather_alg::ParamType>& info) {
             std::string name;
             name += ucc_datatype_str(std::get<0>(info.param));

--- a/test/gtest/coll/test_allgather.cc
+++ b/test/gtest/coll/test_allgather.cc
@@ -199,7 +199,8 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -245,7 +246,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -287,7 +289,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_allgatherv.cc
+++ b/test/gtest/coll/test_allgatherv.cc
@@ -214,7 +214,8 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA), // mem type
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED), // mem type
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -259,7 +260,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_allreduce.cc
+++ b/test/gtest/coll/test_allreduce.cc
@@ -213,6 +213,23 @@ TYPED_TEST(test_allreduce_cuda, single_persistent_inplace)
 {
     TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 3, 1);
 }
+TYPED_TEST(test_allreduce_cuda, single_managed) {
+    TEST_DECLARE( UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_allreduce_cuda, single_persistent_managed)
+{
+    TEST_DECLARE( UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 3, 1);
+}
+
+TYPED_TEST(test_allreduce_cuda, single_inplace_managed) {
+    TEST_DECLARE( UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_allreduce_cuda, single_persistent_inplace_managed)
+{
+    TEST_DECLARE( UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 3, 1);
+}
 #endif
 
 #define TEST_DECLARE_MULTIPLE(_mem_type, _inplace)                             \
@@ -256,6 +273,13 @@ TYPED_TEST(test_allreduce_cuda, multiple) {
 TYPED_TEST(test_allreduce_cuda, multiple_inplace) {
     TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
 }
+TYPED_TEST(test_allreduce_cuda, multiple_managed) {
+    TEST_DECLARE_MULTIPLE( UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_allreduce_cuda, multiple_inplace_managed) {
+    TEST_DECLARE_MULTIPLE( UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE);
+}
 #endif
 
 template<typename T>
@@ -278,6 +302,9 @@ TYPED_TEST(test_allreduce_alg, sra_knomial_pipelined) {
 
     if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+    if (UCC_OK == ucc_mc_available( UCC_MEMORY_TYPE_CUDA_MANAGED)) {
+        mt.push_back( UCC_MEMORY_TYPE_CUDA_MANAGED);
     }
 
     for (auto count : {65536, 123567}) {
@@ -310,7 +337,7 @@ TYPED_TEST(test_allreduce_alg, rab) {
     UccCollCtxVec ctxs;
     std::vector<ucc_memory_type_t> mt = {UCC_MEMORY_TYPE_HOST};
 
-    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) { //add cuda_managed for cl hier?
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
     }
 
@@ -345,7 +372,7 @@ TYPED_TEST(test_allreduce_alg, rab_pipelined) {
     UccCollCtxVec ctxs;
     std::vector<ucc_memory_type_t> mt = {UCC_MEMORY_TYPE_HOST};
 
-    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) { //add cuda_managed for cl hier?
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
     }
 
@@ -393,6 +420,9 @@ TYPED_TEST(test_allreduce_avg_order, avg_post_op)
 
     if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+    if (UCC_OK == ucc_mc_available( UCC_MEMORY_TYPE_CUDA_MANAGED)) {
+        mt.push_back( UCC_MEMORY_TYPE_CUDA_MANAGED);
     }
 
     for (auto count : {4, 256, 65536}) {

--- a/test/gtest/coll/test_alltoall.cc
+++ b/test/gtest/coll/test_alltoall.cc
@@ -279,7 +279,8 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -324,7 +325,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_alltoallv.cc
+++ b/test/gtest/coll/test_alltoallv.cc
@@ -239,7 +239,8 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Combine(
             ::testing::Range(1, UccJob::nStaticTeams), // team_ids
 #ifdef HAVE_CUDA
-            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                              UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -252,7 +253,8 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Combine(
             ::testing::Range(1, UccJob::nStaticTeams), // team_ids
 #ifdef HAVE_CUDA
-            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                              UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -365,7 +367,8 @@ INSTANTIATE_TEST_CASE_P(
         64, test_alltoallv_2,
         ::testing::Combine(
 #ifdef HAVE_CUDA
-            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                              UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -376,7 +379,8 @@ INSTANTIATE_TEST_CASE_P(
         32, test_alltoallv_3,
         ::testing::Combine(
 #ifdef HAVE_CUDA
-            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+            ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                              UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
             ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_bcast.cc
+++ b/test/gtest/coll/test_bcast.cc
@@ -182,7 +182,8 @@ INSTANTIATE_TEST_CASE_P(
         ::testing::Range(1, UccJob::nStaticTeams), // team_ids
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -232,7 +233,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(
         PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
-        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA),
+        ::testing::Values(UCC_MEMORY_TYPE_HOST, UCC_MEMORY_TYPE_CUDA,
+                          UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
         ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -254,6 +256,9 @@ UCC_TEST_F(test_bcast_alg, 2step) {
 
     if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA_MANAGED)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA_MANAGED);
     }
 
     for (auto count : {8, 65536}) {

--- a/test/gtest/coll/test_gather.cc
+++ b/test/gtest/coll/test_gather.cc
@@ -215,7 +215,8 @@ INSTANTIATE_TEST_CASE_P(
                        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -269,7 +270,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_gatherv.cc
+++ b/test/gtest/coll/test_gatherv.cc
@@ -244,7 +244,8 @@ INSTANTIATE_TEST_CASE_P(
                        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -298,7 +299,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_reduce.cc
+++ b/test/gtest/coll/test_reduce.cc
@@ -212,6 +212,20 @@ TYPED_TEST(test_reduce_cuda, single_inplace) {
 TYPED_TEST(test_reduce_cuda, single_persistent_inplace) {
     TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 3, 1);
 }
+TYPED_TEST(test_reduce_cuda, single_managed) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_reduce_cuda, single_persistent_managed) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 3, 1);
+}
+TYPED_TEST(test_reduce_cuda, single_inplace_managed) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_reduce_cuda, single_persistent_inplace_managed) {
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 3, 1);
+}
 #endif
 
 #define TEST_DECLARE_MULTIPLE(_mem_type, _inplace)                             \
@@ -254,9 +268,14 @@ TYPED_TEST(test_reduce_host, multiple_inplace) {
 TYPED_TEST(test_reduce_cuda, multiple) {
     TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_NO_INPLACE);
 }
-
 TYPED_TEST(test_reduce_cuda, multiple_inplace) {
     TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
+}
+TYPED_TEST(test_reduce_cuda, multiple_managed) {
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE);
+}
+TYPED_TEST(test_reduce_cuda, multiple_inplace_managed) {
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE);
 }
 #endif
 
@@ -277,6 +296,9 @@ TYPED_TEST(test_reduce_avg_order, avg_post_op)
 
     if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA_MANAGED)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA_MANAGED);
     }
 
     for (auto count : {4, 256, 65536}) {

--- a/test/gtest/coll/test_reduce_scatter.cc
+++ b/test/gtest/coll/test_reduce_scatter.cc
@@ -235,6 +235,25 @@ TYPED_TEST(test_reduce_scatter_cuda, single_persistent_inplace)
 {
     TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 3, 1);
 }
+TYPED_TEST(test_reduce_scatter_cuda, single_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_reduce_scatter_cuda, single_persistent_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 3, 1);
+}
+
+TYPED_TEST(test_reduce_scatter_cuda, single_inplace_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_reduce_scatter_cuda, single_persistent_inplace_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 3, 1);
+}
 #endif
 
 #define TEST_DECLARE_MULTIPLE(_mem_type, _inplace)                             \
@@ -285,6 +304,15 @@ TYPED_TEST(test_reduce_scatter_cuda, multiple_inplace)
 {
     TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
 }
+TYPED_TEST(test_reduce_scatter_cuda, multiple_managed)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_reduce_scatter_cuda, multiple_inplace_managed)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE);
+}
 #endif
 
 class test_reduce_scatter_alg
@@ -309,6 +337,9 @@ UCC_TEST_P(test_reduce_scatter_alg, ring)
 
     if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA_MANAGED)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA_MANAGED);
     }
 
     for (auto count : {65536, 123567}) {

--- a/test/gtest/coll/test_reduce_scatterv.cc
+++ b/test/gtest/coll/test_reduce_scatterv.cc
@@ -284,6 +284,25 @@ TYPED_TEST(test_reduce_scatterv_cuda, single_persistent_inplace)
 {
     TEST_DECLARE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE, 3, 1);
 }
+TYPED_TEST(test_reduce_scatterv_cuda, single_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_reduce_scatterv_cuda, single_persistent_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE, 3, 1);
+}
+
+TYPED_TEST(test_reduce_scatterv_cuda, single_inplace_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 1, 0);
+}
+
+TYPED_TEST(test_reduce_scatterv_cuda, single_persistent_inplace_managed)
+{
+    TEST_DECLARE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE, 3, 1);
+}
 #endif
 
 #define TEST_DECLARE_MULTIPLE(_mem_type, _inplace)                             \
@@ -334,6 +353,15 @@ TYPED_TEST(test_reduce_scatterv_cuda, multiple_inplace)
 {
     TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA, TEST_INPLACE);
 }
+TYPED_TEST(test_reduce_scatterv_cuda, multiple_managed)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_NO_INPLACE);
+}
+
+TYPED_TEST(test_reduce_scatterv_cuda, multiple_inplace_managed)
+{
+    TEST_DECLARE_MULTIPLE(UCC_MEMORY_TYPE_CUDA_MANAGED, TEST_INPLACE);
+}
 #endif
 
 class test_reduce_scatterv_alg
@@ -358,6 +386,9 @@ UCC_TEST_P(test_reduce_scatterv_alg, ring)
 
     if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA)) {
         mt.push_back(UCC_MEMORY_TYPE_CUDA);
+    }
+    if (UCC_OK == ucc_mc_available(UCC_MEMORY_TYPE_CUDA_MANAGED)) {
+        mt.push_back(UCC_MEMORY_TYPE_CUDA_MANAGED);
     }
 
     for (auto count : {65536, 123567}) {

--- a/test/gtest/coll/test_scatter.cc
+++ b/test/gtest/coll/test_scatter.cc
@@ -218,7 +218,8 @@ INSTANTIATE_TEST_CASE_P(
                        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -273,7 +274,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/coll/test_scatterv.cc
+++ b/test/gtest/coll/test_scatterv.cc
@@ -245,7 +245,8 @@ INSTANTIATE_TEST_CASE_P(
                        PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif
@@ -299,7 +300,8 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Combine(PREDEFINED_DTYPES,
 #ifdef HAVE_CUDA
                        ::testing::Values(UCC_MEMORY_TYPE_HOST,
-                                         UCC_MEMORY_TYPE_CUDA),
+                                         UCC_MEMORY_TYPE_CUDA,
+                                         UCC_MEMORY_TYPE_CUDA_MANAGED),
 #else
                        ::testing::Values(UCC_MEMORY_TYPE_HOST),
 #endif

--- a/test/gtest/core/test_mc_reduce.cc
+++ b/test/gtest/core/test_mc_reduce.cc
@@ -57,6 +57,9 @@ class test_mc_reduce : public testing::Test {
             }
 #endif
             break;
+        case UCC_MEMORY_TYPE_CUDA_MANAGED:
+            coll_ee_type = UCC_EE_CUDA_STREAM;
+            break;
         case UCC_MEMORY_TYPE_HOST:
             coll_ee_type = UCC_EE_CPU_THREAD;
             break;

--- a/test/gtest/tl/mlx5/test_tl_mlx5_wqe.h
+++ b/test/gtest/tl/mlx5/test_tl_mlx5_wqe.h
@@ -177,8 +177,8 @@ class test_tl_mlx5_dm : public test_tl_mlx5_rdma_write {
         memset(&dm_attr, 0, sizeof(dm_attr));
         dm_attr.length = bufsize;
         dm_ptr         = ibv_alloc_dm(ctx, &dm_attr);
-        ASSERT_TRUE(dm_ptr != NULL);
-        ASSERT_TRUE(errno != 0);
+        GTEST_ASSERT_NE(dm_ptr, nullptr);
+        GTEST_ASSERT_NE(errno, 0);
 
         dm_mr = ibv_reg_dm_mr(pd, dm_ptr, 0, dm_attr.length,
                               IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |

--- a/test/gtest/utils/test_ep_map.cc
+++ b/test/gtest/utils/test_ep_map.cc
@@ -1,7 +1,8 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * See file LICENSE for terms.
  */
+
 extern "C" {
 #include "utils/ucc_coll_utils.h"
 }
@@ -131,7 +132,7 @@ class test_ep_map_inv : public test_ep_map {
     void check_inv(EpMap map)
     {
         ucc_ep_map_t inv;
-        EXPECT_EQ(UCC_OK, ucc_ep_map_create_inverse(map.map, &inv));
+        EXPECT_EQ(UCC_OK, ucc_ep_map_create_inverse(map.map, &inv, 0));
         for (int i = 0; i < map.map.ep_num; i++) {
             EXPECT_EQ(i, ucc_ep_map_eval(inv, ucc_ep_map_eval(map.map, i)));
         }

--- a/test/gtest/utils/test_parser.cc
+++ b/test/gtest/utils/test_parser.cc
@@ -52,7 +52,8 @@ UCC_TEST_F(test_parse_mrange, check_invalid) {
 }
 
 UCC_TEST_F(test_parse_mrange, check_range_multiple) {
-    std::string str = "0-4K:host:8,4k-inf:host:10,0-4k:cuda:7,auto";
+    std::string str      =
+        "0-4K:host:8,4k-inf:host:10,0-4k:cuda:7,0-4k:cuda_managed:6,auto";
     size_t      msgsize1 = 1024, msgsize2 = 8192;
 
     EXPECT_EQ(1, ucc_config_sscanf_uint_ranged(str.c_str(), p, NULL));
@@ -61,6 +62,10 @@ UCC_TEST_F(test_parse_mrange, check_range_multiple) {
     EXPECT_EQ(7, ucc_mrange_uint_get(p, msgsize1, UCC_MEMORY_TYPE_CUDA));
     EXPECT_EQ(UCC_UUNITS_AUTO, ucc_mrange_uint_get(p, msgsize2,
                                                    UCC_MEMORY_TYPE_CUDA));
+    EXPECT_EQ(6, ucc_mrange_uint_get(p, msgsize1,
+                                     UCC_MEMORY_TYPE_CUDA_MANAGED));
+    EXPECT_EQ(UCC_UUNITS_AUTO,
+              ucc_mrange_uint_get(p, msgsize2, UCC_MEMORY_TYPE_CUDA_MANAGED));
     ucc_mrange_uint_destroy(p);
 }
 

--- a/test/mpi/buffer.cc
+++ b/test/mpi/buffer.cc
@@ -31,7 +31,7 @@ void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
     if (mt == UCC_MEMORY_TYPE_CUDA || mt == UCC_MEMORY_TYPE_ROCM) {
         buf = ucc_malloc(count * ucc_dt_size(dt), "buf");
         UCC_MALLOC_CHECK(buf);
-    } else if (mt == UCC_MEMORY_TYPE_HOST) {
+    } else if (mt == UCC_MEMORY_TYPE_HOST || mt == UCC_MEMORY_TYPE_CUDA_MANAGED) {
         buf = _buf;
     } else {
         std::cerr << "Unsupported mt\n";
@@ -85,7 +85,7 @@ void init_buffer(void *_buf, size_t count, ucc_datatype_t dt,
         MPI_Abort(MPI_COMM_WORLD, -1);
         break;
     }
-    if (UCC_MEMORY_TYPE_HOST != mt) {
+    if (UCC_MEMORY_TYPE_HOST != mt && UCC_MEMORY_TYPE_CUDA_MANAGED != mt) {
         UCC_CHECK(ucc_mc_memcpy(_buf, buf, count * ucc_dt_size(dt),
                                 mt, UCC_MEMORY_TYPE_HOST));
         ucc_free(buf);
@@ -148,7 +148,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
     ucc_mc_buffer_header_t *rst_mc_header;
     void *rst = NULL;
 
-    if (UCC_MEMORY_TYPE_HOST == mt) {
+    if (UCC_MEMORY_TYPE_HOST == mt || mt == UCC_MEMORY_TYPE_CUDA_MANAGED) {
         rst = _rst;
     } else if (UCC_MEMORY_TYPE_CUDA == mt || UCC_MEMORY_TYPE_ROCM == mt) {
         UCC_ALLOC_COPY_BUF(rst_mc_header, UCC_MEMORY_TYPE_HOST, _rst, mt,
@@ -182,7 +182,7 @@ ucc_status_t compare_buffers(void *_rst, void *expected, size_t count,
             UCC_ERR_NO_MESSAGE : UCC_OK;
     }
 
-    if (UCC_MEMORY_TYPE_HOST != mt) {
+    if (UCC_MEMORY_TYPE_HOST != mt && UCC_MEMORY_TYPE_CUDA_MANAGED != mt) {
         UCC_CHECK(ucc_mc_free(rst_mc_header));
     }
 

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -88,7 +88,7 @@ void PrintHelp()
             "barrier, allreduce, allgather, allgatherv, bcast, alltoall, alltoallv "
             "reduce, reduce_scatter, reduce_scatterv, gather, gatherv, scatter, scatterv\n\n"
        "-t, --teams            <t1,t2,..>\n\tlist of teams: world,half,reverse,odd_even\n\n"
-       "-M, --mtypes           <m1,m2,..>\n\tlist of mtypes: host,cuda,rocm\n\n"
+       "-M, --mtypes           <m1,m2,..>\n\tlist of mtypes: host,cuda,cudaManaged,rocm\n\n"
        "-d, --dtypes           <d1,d2,..>\n\tlist of dtypes: (u)int8(16,32,64),float32(64,128),float32(64,128)_complex\n\n"
        "-o, --ops              <o1,o2,..>\n\tlist of ops:sum,prod,max,min,land,lor,lxor,band,bor,bxor\n\n"
        "-I, --inplace          <value>\n\t0 - no inplace, 1 - inplace, 2 - both\n\n"
@@ -179,6 +179,8 @@ static ucc_memory_type_t mtype_str_to_type(std::string mtype)
         return UCC_MEMORY_TYPE_HOST;
     } else if (mtype == "cuda") {
         return UCC_MEMORY_TYPE_CUDA;
+    } else if (mtype == "cudaManaged") {
+        return UCC_MEMORY_TYPE_CUDA_MANAGED;
     } else if (mtype == "rocm") {
         return UCC_MEMORY_TYPE_ROCM;
     }

--- a/test/mpi/main.cc
+++ b/test/mpi/main.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * Copyright (c) Advanced Micro Devices, Inc. 2023. ALL RIGHTS RESERVED.
  *
  * See file LICENSE for terms.
@@ -7,8 +7,8 @@
 
 #include <getopt.h>
 #include <sstream>
-#include "test_mpi.h"
 #include <chrono>
+#include "test_mpi.h"
 
 int test_rand_seed = -1;
 static size_t test_max_size = TEST_UCC_RANK_BUF_SIZE_MAX;
@@ -22,32 +22,45 @@ static std::vector<ucc_coll_type_t> colls = {
     UCC_COLL_TYPE_REDUCE_SCATTER, UCC_COLL_TYPE_REDUCE_SCATTERV,
     UCC_COLL_TYPE_GATHER,         UCC_COLL_TYPE_GATHERV,
     UCC_COLL_TYPE_SCATTER,        UCC_COLL_TYPE_SCATTERV};
-static std::vector<ucc_coll_type_t> onesided_colls = {UCC_COLL_TYPE_ALLTOALL};
-static std::vector<ucc_memory_type_t> mtypes = {UCC_MEMORY_TYPE_HOST};
-static std::vector<ucc_datatype_t>    dtypes         = {
+
+static std::vector<ucc_coll_type_t> onesided_colls = {
+    UCC_COLL_TYPE_ALLTOALL};
+
+static std::vector<ucc_memory_type_t> mtypes = {
+    UCC_MEMORY_TYPE_HOST};
+
+static std::vector<ucc_datatype_t> dtypes = {
     UCC_DT_INT16,   UCC_DT_INT32,   UCC_DT_INT64,
     UCC_DT_UINT16,  UCC_DT_UINT32,  UCC_DT_UINT64,
     UCC_DT_FLOAT32, UCC_DT_FLOAT64, UCC_DT_FLOAT64_COMPLEX};
-static std::vector<ucc_reduction_op_t>     ops    = {UCC_OP_SUM, UCC_OP_MAX,
-                                              UCC_OP_AVG};
-static std::vector<ucc_test_mpi_team_t> teams = {TEAM_WORLD, TEAM_REVERSE,
-                                                 TEAM_SPLIT_HALF, TEAM_SPLIT_ODD_EVEN};
-static std::vector<ucc_test_vsize_flag_t> counts_vsize = {TEST_FLAG_VSIZE_32BIT,
-                                                          TEST_FLAG_VSIZE_64BIT};
-static std::vector<ucc_test_vsize_flag_t> displs_vsize = {TEST_FLAG_VSIZE_32BIT,
-                                                          TEST_FLAG_VSIZE_64BIT};
-static size_t msgrange[3] = {8, (1ULL << 21), 8};
-static std::vector<bool> inplace    = {false};
-static std::vector<bool> persistent = {false};
-static std::vector<bool> triggered  = {false};
-static ucc_test_mpi_root_t root_type = ROOT_RANDOM;
-static int root_value = 10;
-static ucc_thread_mode_t                   thread_mode  = UCC_THREAD_SINGLE;
-static int                                 iterations   = 1;
-static int                                 show_help    = 0;
-static int                                 num_tests    = 1;
-static bool                                has_onesided = true;
-static bool                                verbose      = false;
+
+static std::vector<ucc_reduction_op_t> ops = {
+    UCC_OP_SUM, UCC_OP_MAX, UCC_OP_AVG};
+
+static std::vector<ucc_test_mpi_team_t> teams = {
+    TEAM_WORLD, TEAM_REVERSE, TEAM_SPLIT_HALF, TEAM_SPLIT_ODD_EVEN};
+
+static std::vector<ucc_test_vsize_flag_t> counts_vsize = {
+    TEST_FLAG_VSIZE_32BIT, TEST_FLAG_VSIZE_64BIT};
+
+static std::vector<ucc_test_vsize_flag_t> displs_vsize = {
+    TEST_FLAG_VSIZE_32BIT, TEST_FLAG_VSIZE_64BIT};
+
+static size_t msgrange[3] = {
+    8, (1ULL << 21), 8};
+
+static std::vector<bool>   inplace      = {false};
+static std::vector<bool>   persistent   = {false};
+static std::vector<bool>   triggered    = {false};
+static ucc_test_mpi_root_t root_type    = ROOT_RANDOM;
+static int                 root_value   = 10;
+static ucc_thread_mode_t   thread_mode  = UCC_THREAD_SINGLE;
+static int                 iterations   = 1;
+static int                 show_help    = 0;
+static int                 num_tests    = 1;
+static bool                has_onesided = true;
+static bool                verbose      = false;
+
 #if defined(HAVE_CUDA) || defined(HAVE_HIP)
 extern test_set_gpu_device_t test_gpu_set_device;
 #endif
@@ -505,14 +518,15 @@ void ProcessArgs(int argc, char** argv)
 
 int main(int argc, char *argv[])
 {
-    std::chrono::steady_clock::time_point begin =
-        std::chrono::steady_clock::now();
-    int failed = 0;
+    int failed                       = 0;
+    int total_done_skipped_failed[4] = {0};
+    std::chrono::steady_clock::time_point begin;
     int size, required, provided, completed, rank;
     UccTestMpi *test;
     MPI_Request req;
     std::string err;
 
+    begin = std::chrono::steady_clock::now();
     try {
         ProcessArgs(argc, argv);
     } catch (const std::string &s) {
@@ -596,50 +610,50 @@ int main(int argc, char *argv[])
             }
         }
     }
-
     std::cout << std::flush;
-    MPI_Iallreduce(MPI_IN_PLACE, test->results.data(), test->results.size(),
-                   MPI_INT, MPI_MIN, MPI_COMM_WORLD, &req);
+
+    total_done_skipped_failed[0] = test->results.size();
+    for (auto s : test->results) {
+        switch(s) {
+        case UCC_OK:
+            total_done_skipped_failed[1]++;
+            break;
+        case UCC_ERR_NOT_IMPLEMENTED:
+        case UCC_ERR_LAST:
+            total_done_skipped_failed[2]++;
+            break;
+        default:
+            total_done_skipped_failed[3]++;
+        }
+    }
+    MPI_Iallreduce(MPI_IN_PLACE, total_done_skipped_failed,
+                   sizeof(total_done_skipped_failed)/sizeof(int),
+                   MPI_INT, MPI_MAX, MPI_COMM_WORLD, &req);
     do {
         MPI_Test(&req, &completed, MPI_STATUS_IGNORE);
         test->progress_ctx();
     } while(!completed);
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
     if (0 == rank) {
         std::chrono::steady_clock::time_point end =
             std::chrono::steady_clock::now();
-        int skipped = 0;
-        int done = 0;
-        for (auto s : test->results) {
-            switch(s) {
-            case UCC_OK:
-                done++;
-                break;
-            case UCC_ERR_NOT_IMPLEMENTED:
-            case UCC_ERR_LAST:
-                skipped++;
-                break;
-            default:
-                failed++;
-            }
-        }
         std::cout << "\n===== UCC MPI TEST REPORT =====\n" <<
-            "   total tests : " << test->results.size() << "\n" <<
-            "   passed      : " << done << "\n" <<
-            "   skipped     : " << skipped << "\n" <<
-            "   failed      : " << failed << "\n" <<
+            "   total tests : " << total_done_skipped_failed[0] << "\n" <<
+            "   passed      : " << total_done_skipped_failed[1] << "\n" <<
+            "   skipped     : " << total_done_skipped_failed[2] << "\n" <<
+            "   failed      : " << total_done_skipped_failed[3] << "\n" <<
             "   elapsed     : " <<
             std::chrono::duration_cast<std::chrono::seconds>(end - begin).count()
                   << "s" << std::endl;
 
-	if (skipped == test->results.size()) {
+        /* check if all tests have been skipped */
+        if (total_done_skipped_failed[0] == total_done_skipped_failed[2]) {
             std::cout << "\n All tests have been skipped, indicating most likely "
                          "a problem\n";
             failed = 1;
-	}
+        }
     }
+
 test_exit:
     delete test;
 mpi_exit:

--- a/test/mpi/test_case.cc
+++ b/test/mpi/test_case.cc
@@ -67,7 +67,7 @@ std::shared_ptr<TestCase> TestCase::init_single(ucc_test_team_t &_team,
 void TestCase::run(bool triggered)
 {
     if (triggered) {
-        ucc_ee_h ee;
+        ucc_ee_h ee = nullptr;
         ucc_ev_t comp_ev, *post_ev;
         ucc_ee_type_t ee_type;
 


### PR DESCRIPTION
## What
Re-ordering CPPFLAGS and LDFLAGS to prioritize RCCL installation path over ROCM/HIP installation path for ncclCommInitRank check.

## Why ?
Pre-built RCCL libraries and header files can exist in the ROCm installation path, with features (like BFD) that are not supported by all platforms. The current order chooses pre-built RCCL files in the ROCm installation path (if found in the path by `--with-rocm`) over custom-built files in the RCCL installation path (as pointed by `--with-rccl`) when checking for ncclCommInitRank. This fix prioritizes files in the RCCL installation path over ROCm installation path.