### PR TITLE
EC/ROCM: Include stdbool.h to align with new versions of ROCM

### DIFF
--- a/src/components/ec/rocm/ec_rocm_executor_interruptible.c
+++ b/src/components/ec/rocm/ec_rocm_executor_interruptible.c
@@ -5,6 +5,7 @@
  * See file LICENSE for terms.
  */
 
+#include <stdbool.h>
 #include "ec_rocm_executor.h"
 #include "components/mc/ucc_mc.h"
 #include "components/ec/ucc_ec.h"


### PR DESCRIPTION
## What
Adds include stdbool

## Why ?
temporary fix till upstream is fixed
